### PR TITLE
deps(go.mod): bump Go version to 1.23.5 in go.mod and tools/go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/ubuntu-insights
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/ubuntu-insights/tools
 
-go 1.23.4
+go 1.23.5
 
 require github.com/golangci/golangci-lint v1.63.4
 


### PR DESCRIPTION
Bump Go version from 1.23.4 to 1.23.5. 

Includes security changes to the standard library, fixing some linter errors.