### PR TITLE
deps(go.mod): bump Go version to 1.23.6 in go.mod and tools/go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/ubuntu-insights
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/ubuntu-insights/tools
 
-go 1.23.5
+go 1.23.6
 
 require github.com/golangci/golangci-lint v1.63.4
 


### PR DESCRIPTION
Bump Go version from 1.23.5 to 1.23.6.

https://github.com/golang/go/issues?q=milestone%3AGo1.23.6+label%3ACherryPickApproved