### PR TITLE
fix(.golangci.yaml): Fix nolintlint in golangci-lint config 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,10 +57,6 @@ issues:
     # G601: Implicit memory aliasing in for loop.
     - G601
 
-nolintlint:
-  require-explanation: true
-  require-specific: true
-
 linters-settings:
   # Forbid the usage of deprecated ioutil and debug prints
   forbidigo:
@@ -70,3 +66,8 @@ linters-settings:
   # Never have naked return ever
   nakedret:
     max-func-lines: 1
+
+  # Linting exceptions must be justified and proper
+  nolintlint:
+    require-explanation: true
+    require-specific: true


### PR DESCRIPTION
The new version of `golangci-lint` seems to be more strict on where settings are. This moves `nolintlint` from the top level into `linters-settings`.