### PR TITLE
fix(collect): Fix CLI collect command report printing

### DIFF
--- a/cmd/insights/commands/collect.go
+++ b/cmd/insights/commands/collect.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -87,11 +88,11 @@ func (a App) collectRun() (err error) {
 	}
 
 	// Pretty print insights
-	sInsights, err := json.MarshalIndent(insights, "", "    ")
-	if err != nil {
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, insights, "", "    "); err != nil {
 		return err
 	}
-	fmt.Printf("%+v\n", string(sInsights))
+	fmt.Println(prettyJSON.String())
 
 	err = c.Write(insights)
 


### PR DESCRIPTION
Fix CLI collect command report pretty printing, such that instead of printing bytes, it prints the actual JSON.

---
UDENG-6222