### PR TITLE
feat(collector): omitzero-omitempty non critical parts of the JSON report

### DIFF
--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/platform_darwin
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/platform_darwin
@@ -72,4 +72,4 @@ Unknown-A/local/invalid.json: |-
     }
 Unknown-A/uploaded/1000.json: "{   \n    \"id\": \"1000 Unknown-A uploaded\",\n    \"duplicate\": true\n}"
 Unknown-A/uploaded/1500.json: "{   \n    \"id\": \"1500 Unknown-A uploaded\",\n    \"only in uploaded\": true\n}"
-darwin/local/50000.json: '{"insightsVersion":"Dev","systemInfo":{"hardware":{"product":{"family":"","name":"","vendor":""},"cpu":{"name":"","vendor":"","architecture":"","cpus":0,"sockets":0,"coresPerSocket":0,"threadsPerCore":0},"gpus":null,"memory":{"size":0},"disks":null,"screens":null},"software":{"os":{"family":"","distribution":"","version":""},"timezone":"","language":"","bios":{"vendor":"","version":""}}},"sourceMetrics":null}'
+darwin/local/50000.json: '{"insightsVersion":"Dev","systemInfo":{"hardware":{},"software":{}}}'

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/platform_linux
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/platform_linux
@@ -72,4 +72,4 @@ Unknown-A/local/invalid.json: |-
     }
 Unknown-A/uploaded/1000.json: "{   \n    \"id\": \"1000 Unknown-A uploaded\",\n    \"duplicate\": true\n}"
 Unknown-A/uploaded/1500.json: "{   \n    \"id\": \"1500 Unknown-A uploaded\",\n    \"only in uploaded\": true\n}"
-linux/local/50000.json: '{"insightsVersion":"Dev","systemInfo":{"hardware":{"product":{"family":"","name":"","vendor":""},"cpu":{"name":"","vendor":"","architecture":"","cpus":0,"sockets":0,"coresPerSocket":0,"threadsPerCore":0},"gpus":null,"memory":{"size":0},"disks":null,"screens":null},"software":{"os":{"family":"","distribution":"","version":""},"timezone":"","language":"","bios":{"vendor":"","version":""}}},"sourceMetrics":null}'
+linux/local/50000.json: '{"insightsVersion":"Dev","systemInfo":{"hardware":{},"software":{}}}'

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/platform_windows
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/platform_windows
@@ -72,4 +72,4 @@ Unknown-A/local/invalid.json: |-
     }
 Unknown-A/uploaded/1000.json: "{   \n    \"id\": \"1000 Unknown-A uploaded\",\n    \"duplicate\": true\n}"
 Unknown-A/uploaded/1500.json: "{   \n    \"id\": \"1500 Unknown-A uploaded\",\n    \"only in uploaded\": true\n}"
-windows/local/50000.json: '{"insightsVersion":"Dev","systemInfo":{"hardware":{"product":{"family":"","name":"","vendor":""},"cpu":{"name":"","vendor":"","architecture":"","cpus":0,"sockets":0,"coresPerSocket":0,"threadsPerCore":0},"gpus":null,"memory":{"size":0},"disks":null,"screens":null},"software":{"os":{"family":"","distribution":"","version":""},"timezone":"","language":"","bios":{"vendor":"","version":""}}},"sourceMetrics":null}'
+windows/local/50000.json: '{"insightsVersion":"Dev","systemInfo":{"hardware":{},"software":{}}}'

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/true_bad-ext
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/true_bad-ext
@@ -44,7 +44,7 @@ True/local/2501.json: |-
     {
         "id": "2501 True local"
     }
-True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{\"product\":{\"family\":\"\",\"name\":\"\",\"vendor\":\"\"},\"cpu\":{\"name\":\"\",\"vendor\":\"\",\"architecture\":\"\",\"cpus\":0,\"sockets\":0,\"coresPerSocket\":0,\"threadsPerCore\":0},\"gpus\":null,\"memory\":{\"size\":0},\"disks\":null,\"screens\":null},\"software\":{\"os\":{\"family\":\"\",\"distribution\":\"\",\"version\":\"\"},\"timezone\":\"\",\"language\":\"\",\"bios\":{\"vendor\":\"\",\"version\":\"\"}}},\"sourceMetrics\":{\"data_array\":[1,2,3],\"data_bool\":true,\"data_float\":1.1,\"data_int\":1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
+True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{},\"software\":{}},\"sourceMetrics\":{\"data_array\":[1,2,3],\"data_bool\":true,\"data_float\":1.1,\"data_int\":1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
 True/local/invalid.json: "{   \n    \"id\": \"invalid True local\"\n}"
 True/uploaded/1000.json: "{   \n    \"id\": \"1000 True uploaded\",\n    \"duplicate\": true\n}"
 True/uploaded/1500.json: |-

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal
@@ -44,7 +44,7 @@ True/local/2501.json: |-
     {
         "id": "2501 True local"
     }
-True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{\"product\":{\"family\":\"\",\"name\":\"\",\"vendor\":\"\"},\"cpu\":{\"name\":\"\",\"vendor\":\"\",\"architecture\":\"\",\"cpus\":0,\"sockets\":0,\"coresPerSocket\":0,\"threadsPerCore\":0},\"gpus\":null,\"memory\":{\"size\":0},\"disks\":null,\"screens\":null},\"software\":{\"os\":{\"family\":\"\",\"distribution\":\"\",\"version\":\"\"},\"timezone\":\"\",\"language\":\"\",\"bios\":{\"vendor\":\"\",\"version\":\"\"}}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
+True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{},\"software\":{}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
 True/local/invalid.json: "{   \n    \"id\": \"invalid True local\"\n}"
 True/uploaded/1000.json: "{   \n    \"id\": \"1000 True uploaded\",\n    \"duplicate\": true\n}"
 True/uploaded/1500.json: |-

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_force
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_force
@@ -44,7 +44,7 @@ True/local/2501.json: |-
     {
         "id": "2501 True local"
     }
-True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{\"product\":{\"family\":\"\",\"name\":\"\",\"vendor\":\"\"},\"cpu\":{\"name\":\"\",\"vendor\":\"\",\"architecture\":\"\",\"cpus\":0,\"sockets\":0,\"coresPerSocket\":0,\"threadsPerCore\":0},\"gpus\":null,\"memory\":{\"size\":0},\"disks\":null,\"screens\":null},\"software\":{\"os\":{\"family\":\"\",\"distribution\":\"\",\"version\":\"\"},\"timezone\":\"\",\"language\":\"\",\"bios\":{\"vendor\":\"\",\"version\":\"\"}}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
+True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{},\"software\":{}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
 True/local/invalid.json: "{   \n    \"id\": \"invalid True local\"\n}"
 True/uploaded/1000.json: "{   \n    \"id\": \"1000 True uploaded\",\n    \"duplicate\": true\n}"
 True/uploaded/1500.json: |-

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_force_period
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_force_period
@@ -44,7 +44,7 @@ True/local/2501.json: |-
     {
         "id": "2501 True local"
     }
-True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{\"product\":{\"family\":\"\",\"name\":\"\",\"vendor\":\"\"},\"cpu\":{\"name\":\"\",\"vendor\":\"\",\"architecture\":\"\",\"cpus\":0,\"sockets\":0,\"coresPerSocket\":0,\"threadsPerCore\":0},\"gpus\":null,\"memory\":{\"size\":0},\"disks\":null,\"screens\":null},\"software\":{\"os\":{\"family\":\"\",\"distribution\":\"\",\"version\":\"\"},\"timezone\":\"\",\"language\":\"\",\"bios\":{\"vendor\":\"\",\"version\":\"\"}}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
+True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{},\"software\":{}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
 True/local/invalid.json: "{   \n    \"id\": \"invalid True local\"\n}"
 True/uploaded/1000.json: "{   \n    \"id\": \"1000 True uploaded\",\n    \"duplicate\": true\n}"
 True/uploaded/1500.json: |-

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_global_bad-file
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_global_bad-file
@@ -44,7 +44,7 @@ True/local/2501.json: |-
     {
         "id": "2501 True local"
     }
-True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{\"product\":{\"family\":\"\",\"name\":\"\",\"vendor\":\"\"},\"cpu\":{\"name\":\"\",\"vendor\":\"\",\"architecture\":\"\",\"cpus\":0,\"sockets\":0,\"coresPerSocket\":0,\"threadsPerCore\":0},\"gpus\":null,\"memory\":{\"size\":0},\"disks\":null,\"screens\":null},\"software\":{\"os\":{\"family\":\"\",\"distribution\":\"\",\"version\":\"\"},\"timezone\":\"\",\"language\":\"\",\"bios\":{\"vendor\":\"\",\"version\":\"\"}}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
+True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{},\"software\":{}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
 True/local/invalid.json: "{   \n    \"id\": \"invalid True local\"\n}"
 True/uploaded/1000.json: "{   \n    \"id\": \"1000 True uploaded\",\n    \"duplicate\": true\n}"
 True/uploaded/1500.json: |-

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_global_false
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_global_false
@@ -44,7 +44,7 @@ True/local/2501.json: |-
     {
         "id": "2501 True local"
     }
-True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{\"product\":{\"family\":\"\",\"name\":\"\",\"vendor\":\"\"},\"cpu\":{\"name\":\"\",\"vendor\":\"\",\"architecture\":\"\",\"cpus\":0,\"sockets\":0,\"coresPerSocket\":0,\"threadsPerCore\":0},\"gpus\":null,\"memory\":{\"size\":0},\"disks\":null,\"screens\":null},\"software\":{\"os\":{\"family\":\"\",\"distribution\":\"\",\"version\":\"\"},\"timezone\":\"\",\"language\":\"\",\"bios\":{\"vendor\":\"\",\"version\":\"\"}}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
+True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{},\"software\":{}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
 True/local/invalid.json: "{   \n    \"id\": \"invalid True local\"\n}"
 True/uploaded/1000.json: "{   \n    \"id\": \"1000 True uploaded\",\n    \"duplicate\": true\n}"
 True/uploaded/1500.json: |-

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_maxreports
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/true_normal_maxreports
@@ -30,7 +30,7 @@ True/local/2501.json: |-
     {
         "id": "2501 True local"
     }
-True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{\"product\":{\"family\":\"\",\"name\":\"\",\"vendor\":\"\"},\"cpu\":{\"name\":\"\",\"vendor\":\"\",\"architecture\":\"\",\"cpus\":0,\"sockets\":0,\"coresPerSocket\":0,\"threadsPerCore\":0},\"gpus\":null,\"memory\":{\"size\":0},\"disks\":null,\"screens\":null},\"software\":{\"os\":{\"family\":\"\",\"distribution\":\"\",\"version\":\"\"},\"timezone\":\"\",\"language\":\"\",\"bios\":{\"vendor\":\"\",\"version\":\"\"}}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
+True/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{},\"software\":{}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
 True/local/invalid.json: "{   \n    \"id\": \"invalid True local\"\n}"
 True/uploaded/1000.json: "{   \n    \"id\": \"1000 True uploaded\",\n    \"duplicate\": true\n}"
 True/uploaded/1500.json: |-

--- a/cmd/insights/integration-tests/testdata/TestCollect/golden/unknown-a_normal
+++ b/cmd/insights/integration-tests/testdata/TestCollect/golden/unknown-a_normal
@@ -65,7 +65,7 @@ Unknown-A/local/2501.json: |-
     {
         "id": "2501 Unknown-A local"
     }
-Unknown-A/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{\"product\":{\"family\":\"\",\"name\":\"\",\"vendor\":\"\"},\"cpu\":{\"name\":\"\",\"vendor\":\"\",\"architecture\":\"\",\"cpus\":0,\"sockets\":0,\"coresPerSocket\":0,\"threadsPerCore\":0},\"gpus\":null,\"memory\":{\"size\":0},\"disks\":null,\"screens\":null},\"software\":{\"os\":{\"family\":\"\",\"distribution\":\"\",\"version\":\"\"},\"timezone\":\"\",\"language\":\"\",\"bios\":{\"vendor\":\"\",\"version\":\"\"}}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
+Unknown-A/local/50000.json: "{\"insightsVersion\":\"Dev\",\"systemInfo\":{\"hardware\":{},\"software\":{}},\"sourceMetrics\":{\"data_array\":[1.1,2.2,3.3],\"data_bool\":true,\"data_float\":1.1,\"data_object\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"data_string\":\"string\",\"runes\":\"\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525\"}}"
 Unknown-A/local/invalid.json: |-
     {
         "id": "invalid Unknown-A local",

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -25,7 +25,7 @@ var ErrDuplicateReport = fmt.Errorf("report already exists for this period")
 type Insights struct {
 	InsightsVersion string         `json:"insightsVersion"`
 	SysInfo         sysinfo.Info   `json:"systemInfo"`
-	SourceMetrics   map[string]any `json:"sourceMetrics"`
+	SourceMetrics   map[string]any `json:"sourceMetrics,omitempty"`
 }
 
 type timeProvider interface {

--- a/internal/collector/sysinfo/hardware/hardware.go
+++ b/internal/collector/sysinfo/hardware/hardware.go
@@ -10,12 +10,12 @@ import (
 
 // Info aggregates hardware info.
 type Info struct {
-	Product product  `json:"product"`
-	CPU     cpu      `json:"cpu"`
-	GPUs    []gpu    `json:"gpus"`
-	Mem     memory   `json:"memory"`
-	Blks    []disk   `json:"disks"`
-	Screens []screen `json:"screens"`
+	Product product  `json:"product,omitzero"`
+	CPU     cpu      `json:"cpu,omitzero"`
+	GPUs    []gpu    `json:"gpus,omitempty"`
+	Mem     memory   `json:"memory,omitzero"`
+	Blks    []disk   `json:"disks,omitempty"`
+	Screens []screen `json:"screens,omitempty"`
 }
 
 // product contains information for a system's product.

--- a/internal/collector/sysinfo/software/software.go
+++ b/internal/collector/sysinfo/software/software.go
@@ -11,10 +11,10 @@ import (
 
 // Info is the software specific part.
 type Info struct {
-	OS       osInfo `json:"os"`
-	Timezone string `json:"timezone"`
-	Lang     string `json:"language"`
-	Bios     bios   `json:"bios"`
+	OS       osInfo `json:"os,omitzero"`
+	Timezone string `json:"timezone,omitempty"`
+	Lang     string `json:"language,omitempty"`
+	Bios     bios   `json:"bios,omitzero"`
 }
 
 type osInfo struct {

--- a/internal/collector/sysinfo/testdata/TestCollect/golden/hardware_and_software_error_warns
+++ b/internal/collector/sysinfo/testdata/TestCollect/golden/hardware_and_software_error_warns
@@ -1,37 +1,4 @@
 {
-  "hardware": {
-    "product": {
-      "family": "",
-      "name": "",
-      "vendor": ""
-    },
-    "cpu": {
-      "name": "",
-      "vendor": "",
-      "architecture": "",
-      "cpus": 0,
-      "sockets": 0,
-      "coresPerSocket": 0,
-      "threadsPerCore": 0
-    },
-    "gpus": null,
-    "memory": {
-      "size": 0
-    },
-    "disks": null,
-    "screens": null
-  },
-  "software": {
-    "os": {
-      "family": "",
-      "distribution": "",
-      "version": ""
-    },
-    "timezone": "",
-    "language": "",
-    "bios": {
-      "vendor": "",
-      "version": ""
-    }
-  }
+  "hardware": {},
+  "software": {}
 }

--- a/internal/collector/testdata/TestCompile/golden/basic
+++ b/internal/collector/testdata/TestCompile/golden/basic
@@ -1,31 +1,4 @@
 insightsVersion: Dev
-sourceMetrics: null
 systemInfo:
-    hardware:
-        cpu:
-            architecture: ""
-            coresPerSocket: 0
-            cpus: 0
-            name: ""
-            sockets: 0
-            threadsPerCore: 0
-            vendor: ""
-        disks: null
-        gpus: null
-        memory:
-            size: 0
-        product:
-            family: ""
-            name: ""
-            vendor: ""
-        screens: null
-    software:
-        bios:
-            vendor: ""
-            version: ""
-        language: ""
-        os:
-            distribution: ""
-            family: ""
-            version: ""
-        timezone: ""
+    hardware: {}
+    software: {}

--- a/internal/collector/testdata/TestCompile/golden/dry_run
+++ b/internal/collector/testdata/TestCompile/golden/dry_run
@@ -1,31 +1,4 @@
 insightsVersion: Dev
-sourceMetrics: null
 systemInfo:
-    hardware:
-        cpu:
-            architecture: ""
-            coresPerSocket: 0
-            cpus: 0
-            name: ""
-            sockets: 0
-            threadsPerCore: 0
-            vendor: ""
-        disks: null
-        gpus: null
-        memory:
-            size: 0
-        product:
-            family: ""
-            name: ""
-            vendor: ""
-        screens: null
-    software:
-        bios:
-            vendor: ""
-            version: ""
-        language: ""
-        os:
-            distribution: ""
-            family: ""
-            version: ""
-        timezone: ""
+    hardware: {}
+    software: {}

--- a/internal/collector/testdata/TestCompile/golden/duplicate_report_force
+++ b/internal/collector/testdata/TestCompile/golden/duplicate_report_force
@@ -1,31 +1,4 @@
 insightsVersion: Dev
-sourceMetrics: null
 systemInfo:
-    hardware:
-        cpu:
-            architecture: ""
-            coresPerSocket: 0
-            cpus: 0
-            name: ""
-            sockets: 0
-            threadsPerCore: 0
-            vendor: ""
-        disks: null
-        gpus: null
-        memory:
-            size: 0
-        product:
-            family: ""
-            name: ""
-            vendor: ""
-        screens: null
-    software:
-        bios:
-            vendor: ""
-            version: ""
-        language: ""
-        os:
-            distribution: ""
-            family: ""
-            version: ""
-        timezone: ""
+    hardware: {}
+    software: {}

--- a/internal/collector/testdata/TestCompile/golden/with_sourcemetrics
+++ b/internal/collector/testdata/TestCompile/golden/with_sourcemetrics
@@ -12,31 +12,5 @@ sourceMetrics:
     data_string: string
     runes: "\U0001F525☆*: .｡. o(≧▽≦)o .｡.:*☆\U0001F525"
 systemInfo:
-    hardware:
-        cpu:
-            architecture: ""
-            coresPerSocket: 0
-            cpus: 0
-            name: ""
-            sockets: 0
-            threadsPerCore: 0
-            vendor: ""
-        disks: null
-        gpus: null
-        memory:
-            size: 0
-        product:
-            family: ""
-            name: ""
-            vendor: ""
-        screens: null
-    software:
-        bios:
-            vendor: ""
-            version: ""
-        language: ""
-        os:
-            distribution: ""
-            family: ""
-            version: ""
-        timezone: ""
+    hardware: {}
+    software: {}

--- a/internal/collector/testdata/TestWrite/golden/basic
+++ b/internal/collector/testdata/TestWrite/golden/basic
@@ -1,6 +1,6 @@
 local/5.json: ""
 local/5.txt: ""
-local/10.json: '{"insightsVersion":"","systemInfo":{"hardware":{"product":{"family":"","name":"","vendor":""},"cpu":{"name":"","vendor":"","architecture":"","cpus":0,"sockets":0,"coresPerSocket":0,"threadsPerCore":0},"gpus":null,"memory":{"size":0},"disks":null,"screens":null},"software":{"os":{"family":"","distribution":"","version":""},"timezone":"","language":"","bios":{"vendor":"","version":""}}},"sourceMetrics":null}'
+local/10.json: '{"insightsVersion":"","systemInfo":{"hardware":{},"software":{}}}'
 local/20.json: ""
 uploaded/5.json: ""
 uploaded/30.json: ""

--- a/internal/collector/testdata/TestWrite/golden/max_reports
+++ b/internal/collector/testdata/TestWrite/golden/max_reports
@@ -1,5 +1,5 @@
 local/5.txt: ""
-local/10.json: '{"insightsVersion":"","systemInfo":{"hardware":{"product":{"family":"","name":"","vendor":""},"cpu":{"name":"","vendor":"","architecture":"","cpus":0,"sockets":0,"coresPerSocket":0,"threadsPerCore":0},"gpus":null,"memory":{"size":0},"disks":null,"screens":null},"software":{"os":{"family":"","distribution":"","version":""},"timezone":"","language":"","bios":{"vendor":"","version":""}}},"sourceMetrics":null}'
+local/10.json: '{"insightsVersion":"","systemInfo":{"hardware":{},"software":{}}}'
 local/20.json: ""
 uploaded/5.json: ""
 uploaded/30.json: ""

--- a/internal/collector/testdata/TestWrite/golden/no_dir
+++ b/internal/collector/testdata/TestWrite/golden/no_dir
@@ -1,1 +1,1 @@
-local/10.json: '{"insightsVersion":"","systemInfo":{"hardware":{"product":{"family":"","name":"","vendor":""},"cpu":{"name":"","vendor":"","architecture":"","cpus":0,"sockets":0,"coresPerSocket":0,"threadsPerCore":0},"gpus":null,"memory":{"size":0},"disks":null,"screens":null},"software":{"os":{"family":"","distribution":"","version":""},"timezone":"","language":"","bios":{"vendor":"","version":""}}},"sourceMetrics":null}'
+local/10.json: '{"insightsVersion":"","systemInfo":{"hardware":{},"software":{}}}'


### PR DESCRIPTION
For clarity, use the omitzero and omitempty tags for relevant parts of the structs being compiled into the JSON report. 

This is primarily done for sections, and it is not applied to all fields for cases where it is expected that one part of the section was gotten, but was not for whatever reason. For example, if for BIOS, vendor was filled but not version, both fields will remain.

---
UDENG-6329