### PR TITLE
deps(go.mod): Bump Go version to 1.24.1 in go.mod and tools/go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/ubuntu-insights
 
-go 1.24.0
+go 1.24.1
 
 require (
 	github.com/BurntSushi/toml v1.4.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/ubuntu-insights/tools
 
-go 1.24.0
+go 1.24.1
 
 require github.com/golangci/golangci-lint v1.64.6
 


### PR DESCRIPTION
Bumps Go version to 1.24.1 in go.mod and tools/go.mod from 1.24.0.