### PR TITLE
fix(integrationtests): Fix error formatting in integration tests sysinfo handling; spelling fix

### DIFF
--- a/cmd/insights/integrationtests.go
+++ b/cmd/insights/integrationtests.go
@@ -21,7 +21,7 @@ func (m MockTimeProvider) Now() time.Time {
 	return time.Unix(m.CurrentTime, 0)
 }
 
-// load any behaviour modifiers from env variable.
+// load any behavior modifiers from env variable.
 func init() {
 	if server_url := os.Getenv("UBUNTU_INSIGHTS_INTEGRATIONTESTS_SERVER_URL"); server_url != "" {
 		uploadertestutils.SetServerURL(server_url)
@@ -72,7 +72,7 @@ func init() {
 	if os.Getenv("UBUNTU_INSIGHTS_INTEGRATIONTESTS_SYSINFO") != "" {
 		si := testSysInfo{}
 		if sysinfoErr := os.Getenv("UBUNTU_INSIGHTS_INTEGRATIONTESTS_SYSINFO_ERR"); sysinfoErr != "" {
-			si.err = fmt.Errorf(sysinfoErr)
+			si.err = fmt.Errorf("%s", sysinfoErr)
 		}
 		collectortestutils.SetSysInfo(si)
 	}


### PR DESCRIPTION
Fix error formatting in integration tests for syninfo handling that broke cmd main tests.

Small spelling fix to American English.