### PR TITLE
feat(sysinfo/hardware): Add special handling for the WSL 1 case for collectDisk

### DIFF
--- a/internal/collector/sysinfo/hardware/hardware.go
+++ b/internal/collector/sysinfo/hardware/hardware.go
@@ -134,7 +134,7 @@ func (h Collector) Collect(pi platform.Info) (info Info, err error) {
 		info.Mem = memory{}
 	}
 
-	info.Blks, err = h.collectDisks()
+	info.Blks, err = h.collectDisks(pi)
 	if err != nil {
 		h.log.Warn("failed to collect disk info", "error", err)
 		info.Blks = []disk{}

--- a/internal/collector/sysinfo/hardware/hardware_darwin.go
+++ b/internal/collector/sysinfo/hardware/hardware_darwin.go
@@ -25,7 +25,7 @@ func (s Collector) collectMemory() (memory, error) {
 	return memory{}, nil
 }
 
-func (s Collector) collectDisks() ([]disk, error) {
+func (s Collector) collectDisks(platform.Info) ([]disk, error) {
 	return []disk{}, nil
 }
 

--- a/internal/collector/sysinfo/hardware/hardware_linux_test.go
+++ b/internal/collector/sysinfo/hardware/hardware_linux_test.go
@@ -308,6 +308,29 @@ func TestCollectLinux(t *testing.T) {
 				},
 			},
 		},
+		"WSL 1 hardware information": {
+			root:       "regular",
+			cpuInfo:    "regular",
+			blkInfo:    "error",
+			screenInfo: "error",
+			missingFiles: []string{
+				// Product
+				"sys/class/dmi/id/product_family",
+				"sys/class/dmi/id/product_name",
+				"sys/class/dmi/id/sys_vendor",
+				// GPU
+				"sys/class/drm/c0",
+				"sys/class/drm/c1",
+				"sys/class/drm/card0-DP-1",
+				"sys/class/drm/card0-DP-2",
+				"sys/class/drm/card1",
+			},
+			pinfo: platform.Info{
+				WSL: platform.WSL{
+					SubsystemVersion: 1,
+				},
+			},
+		},
 		"WSL hardware information with xrandr": {
 			root:       "regular",
 			cpuInfo:    "regular",

--- a/internal/collector/sysinfo/hardware/hardware_windows.go
+++ b/internal/collector/sysinfo/hardware/hardware_windows.go
@@ -168,7 +168,7 @@ func (s Collector) collectMemory() (mem memory, err error) {
 }
 
 // collectDisks uses Win32_DiskDrive and Win32_DiskPartition to collect information about disks.
-func (s Collector) collectDisks() (blks []disk, err error) {
+func (s Collector) collectDisks(platform.Info) (blks []disk, err error) {
 	var usedDiskFields = map[string]struct{}{
 		"Name":       {},
 		"Size":       {},

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wsl_1_hardware_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wsl_1_hardware_information
@@ -1,0 +1,17 @@
+product:
+    family: ""
+    name: ""
+    vendor: ""
+cpu:
+    name: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+    vendor: GenuineIntel
+    arch: x86_64
+    cpus: 12
+    sockets: 1
+    cores: 6
+    threads: 2
+gpus: []
+mem:
+    total: 31941
+blks: []
+screens: []


### PR DESCRIPTION
Add special handling for the WSL 1 case for collectDisk, where if lsblk fails, the error is silenced as this is expected.

---
[UDENG-6395](https://warthogs.atlassian.net/browse/UDENG-6395)

[UDENG-6395]: https://warthogs.atlassian.net/browse/UDENG-6395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ