### PR TITLE
feat(cmd): Improve command usage descriptions for clarity and consistency

### DIFF
--- a/cmd/insights/commands/collect.go
+++ b/cmd/insights/commands/collect.go
@@ -16,11 +16,12 @@ import (
 
 func installCollectCmd(app *App) {
 	collectCmd := &cobra.Command{
-		Use:   "collect [SOURCE] [SOURCE-METRICS-PATH](required if source provided)",
+		Use:   "collect [source] [source-metrics-path](required if source provided)",
 		Short: "Collect system information",
 		Long: `Collect system information and metrics and store it locally.
-		If SOURCE is not provided, then it is the source is assumed to be the currently detected platform. Additionally, there should be no SOURCE-METRICS-PATH provided.
-		If SOURCE is provided, then the SOURCE-METRICS-PATH should be provided as well.`,
+
+If source is not provided, then the source is assumed to be the currently detected platform. Additionally, there should be no source-metrics-path provided.
+If source is provided, then the source-metrics-path should be provided as well.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if err := cobra.MaximumNArgs(2)(cmd, args); err != nil {
 				return err

--- a/cmd/insights/commands/consent.go
+++ b/cmd/insights/commands/consent.go
@@ -46,6 +46,13 @@ If no sources are provided, the global consent state is managed.`,
 		},
 	}
 
+	consentCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
+		if err := command.Flags().MarkHidden("insights-dir"); err != nil {
+			slog.Error("Failed to hide insights-dir flag", "error", err)
+		}
+		command.Parent().HelpFunc()(command, strings)
+	})
+
 	consentCmd.Flags().StringVarP(&app.config.Consent.State, "state", "s", "", "the consent state to set (true or false)")
 
 	app.cmd.AddCommand(consentCmd)

--- a/cmd/insights/commands/consent.go
+++ b/cmd/insights/commands/consent.go
@@ -13,10 +13,12 @@ import (
 
 func installConsentCmd(app *App) {
 	consentCmd := &cobra.Command{
-		Use:   "consent [SOURCES](optional arguments)",
+		Use:   "consent [sources](optional arguments)",
 		Short: "Manage or get user consent state",
-		Long:  "Manage or get user consent state for data collection and upload",
-		Args:  cobra.ArbitraryArgs,
+		Long: `Manage or get user consent state for data collection and upload.
+		
+If no sources are provided, the global consent state is managed.`,
+		Args: cobra.ArbitraryArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := strconv.ParseBool(app.config.Consent.State); app.config.Consent.State != "" && err != nil {
 				app.cmd.SilenceUsage = false
@@ -44,7 +46,7 @@ func installConsentCmd(app *App) {
 		},
 	}
 
-	consentCmd.Flags().StringVarP(&app.config.Consent.State, "state", "s", "", "the consent state to set (true or false), the current consent state is displayed if not set")
+	consentCmd.Flags().StringVarP(&app.config.Consent.State, "state", "s", "", "the consent state to set (true or false)")
 
 	app.cmd.AddCommand(consentCmd)
 }

--- a/cmd/insights/commands/root.go
+++ b/cmd/insights/commands/root.go
@@ -70,8 +70,12 @@ func New(args ...Options) (*App, error) {
 		newCollector: opts.newCollector,
 	}
 	a.cmd = &cobra.Command{
-		Use:           constants.CmdName + " [COMMAND]",
-		Long:          "",
+		Use:   constants.CmdName,
+		Short: "A transparent tool to collect and share anonymous insights about your system",
+		Long: `A transparent tool to collect and share anonymous insights about your system.
+		
+If consent is given, this tool collects non-personally identifying hardware, software, and platform information, and shares it with the Ubuntu Development team.
+The information collected can't be used to identify a single machine. All reports are cached on the local machine and can be reviewed before and after uploading.`,
 		SilenceErrors: true,
 		Version:       constants.Version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/insights/commands/upload.go
+++ b/cmd/insights/commands/upload.go
@@ -15,8 +15,12 @@ const defaultMinAge = 604800
 
 func installUploadCmd(app *App) {
 	uploadCmd := &cobra.Command{
-		Use:  "upload [sources](optional arguments)",
-		Long: "Upload metrics to the Ubuntu Insights server",
+		Use:   "upload [sources](optional arguments)",
+		Short: "Upload metrics to the Ubuntu Insights server",
+		Long: `Upload metrics to the Ubuntu Insights server.
+		
+If no sources are provided, all detected sources at the configured reports directory will be uploaded.
+If consent is not given for a source, an opt-out notification will be sent regardless of the locally cached insights report's contents.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Persist viper config if no args passed
@@ -40,8 +44,8 @@ func installUploadCmd(app *App) {
 	}
 
 	uploadCmd.Flags().UintVar(&app.config.Upload.MinAge, "min-age", defaultMinAge, "the minimum age (in seconds) of a report before the uploader will attempt to upload it")
-	uploadCmd.Flags().BoolVarP(&app.config.Upload.Force, "force", "f", false, "force an upload, ignoring min age and clashes between the collected file and a file in the uploaded folder, replacing the clashing uploaded report if it exists")
-	uploadCmd.Flags().BoolVarP(&app.config.Upload.DryRun, "dry-run", "d", false, "go through the motions of doing an upload, but do not communicate with the server or send the payload")
+	uploadCmd.Flags().BoolVarP(&app.config.Upload.Force, "force", "f", false, "force an upload, ignoring min age and clashes between the collected file and a file in the uploaded folder, replacing the clashing uploaded report if it exists (doesn't ignore consent)")
+	uploadCmd.Flags().BoolVarP(&app.config.Upload.DryRun, "dry-run", "d", false, "go through the motions of doing an upload, but do not communicate with the server, send the payload, or modify local files")
 	uploadCmd.Flags().BoolVarP(&app.config.Upload.Retry, "retry", "r", false, "enable a limited number of retries for failed uploads")
 
 	app.cmd.AddCommand(uploadCmd)


### PR DESCRIPTION
Improve command usage descriptions for clarity and consistency.

Hide `insights-dir` flag for the consent command.

---
UDENG-6487