### PR TITLE
fix(ubuntu-insights-initial-setup): Fix setup consent to use 'linux' instead of 'ubuntu'

### DIFF
--- a/ubuntu-insights-initial-setup
+++ b/ubuntu-insights-initial-setup
@@ -9,10 +9,10 @@ function askQuestion() {
 		askQuestion
 	elif [[ $view_choice =~ ^[Yy]$ ]]; then
 		ubuntu-insights consent -s=true
-		ubuntu-insights consent ubuntu -s=true
+		ubuntu-insights consent linux -s=true
 	elif [[ $view_choice =~ ^[Nn]$ ]]; then
 		ubuntu-insights consent -s=false
-		ubuntu-insights consent ubuntu -s=false
+		ubuntu-insights consent linux -s=false
 	else
 		echo "Invalid input (Y/n/e)."
 		askQuestion


### PR DESCRIPTION
Fix the consent command in the setup script to use 'linux' instead of 'ubuntu' to match the expected source for runtime.GOOS