### PR TITLE
fix(platform): Don't log warning when systemd-detect-virt returns 'none'

### DIFF
--- a/internal/collector/sysinfo/platform/platform_linux.go
+++ b/internal/collector/sysinfo/platform/platform_linux.go
@@ -67,7 +67,9 @@ func (p Collector) collectPlatform() (info Info, err error) {
 func (p Collector) isWSL() bool {
 	stdout, stderr, err := cmdutils.RunWithTimeout(context.Background(), 15*time.Second, p.platform.detectVirtCmd[0], p.platform.detectVirtCmd[1:]...)
 	if err != nil {
-		p.log.Warn("failed to run systemd-detect-virt", "error", err)
+		if !strings.Contains(stdout.String(), "none") {
+			p.log.Warn("failed to run systemd-detect-virt", "error", err)
+		}
 		return false
 	}
 	if stderr.Len() > 0 {

--- a/internal/collector/sysinfo/platform/platform_linux_test.go
+++ b/internal/collector/sysinfo/platform/platform_linux_test.go
@@ -37,13 +37,13 @@ func TestCollectLinux(t *testing.T) {
 	}{
 		// Non-WSL
 		"Non-WSL Basic with Pro Attached": {
-			detectVirtCmd:     "regular",
+			detectVirtCmd:     "none",
 			systemdAnalyzeCmd: "regular",
 			wslVersionCmd:     "error",
 			proStatusCmd:      "attached",
 		},
 		"Non-WSL Basic with Pro Detached": {
-			detectVirtCmd:     "regular",
+			detectVirtCmd:     "none",
 			systemdAnalyzeCmd: "regular",
 			wslVersionCmd:     "error",
 			proStatusCmd:      "detached",
@@ -88,6 +88,13 @@ func TestCollectLinux(t *testing.T) {
 				slog.LevelWarn: 1,
 				slog.LevelInfo: 2,
 			},
+		},
+		// Other virt types
+		"Other virt type (uml) with Pro Attached": {
+			detectVirtCmd:     "uml",
+			systemdAnalyzeCmd: "regular",
+			wslVersionCmd:     "error",
+			proStatusCmd:      "attached",
 		},
 
 		// WSL 2
@@ -432,6 +439,9 @@ func TestFakeVirtInfo(_ *testing.T) {
 		os.Exit(1)
 	case "error no exit":
 		fmt.Fprintf(os.Stderr, "Error requested in fake systemd-detect-virt")
+	case "none":
+		fmt.Println("none")
+		os.Exit(1)
 	case "regular":
 		fmt.Println("uml")
 	case "wsl":

--- a/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/other_virt_type_(uml)_with_pro_attached
+++ b/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/other_virt_type_(uml)_with_pro_attached
@@ -1,0 +1,7 @@
+wsl:
+    subsystemversion: 0
+    systemd: ""
+    interop: ""
+    version: ""
+    kernelversion: ""
+proattached: true


### PR DESCRIPTION
Patch to prevent a warning from being logged when `systemd-detect-virt` returns `none`, even though it returns with exit code 1.

---
UDENG-6493