### PR TITLE
fix(hardware): Fix windows disk-partition collection

### DIFF
--- a/internal/collector/sysinfo/hardware/hardware_windows.go
+++ b/internal/collector/sysinfo/hardware/hardware_windows.go
@@ -228,6 +228,10 @@ func (s Collector) collectDisks() (blks []disk, err error) {
 			s.log.Warn("disk index was larger than disks", "value", idx)
 			continue
 		}
+		if blks[idx].Size != 0 {
+			s.log.Warn("duplicate disk index", "value", idx)
+			continue
+		}
 		blks[idx] = c
 	}
 

--- a/internal/collector/sysinfo/hardware/hardware_windows_test.go
+++ b/internal/collector/sysinfo/hardware/hardware_windows_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,7 @@ import (
 	"github.com/ubuntu/ubuntu-insights/internal/collector/sysinfo/hardware"
 	"github.com/ubuntu/ubuntu-insights/internal/collector/sysinfo/platform"
 	"github.com/ubuntu/ubuntu-insights/internal/testutils"
+	"gopkg.in/yaml.v3"
 )
 
 func TestMain(m *testing.M) {
@@ -305,7 +307,7 @@ func TestCollectWindows(t *testing.T) {
 			screenSizeInfo: "regular",
 
 			logs: map[slog.Level]uint{
-				slog.LevelWarn: 3,
+				slog.LevelWarn: 12,
 			},
 		},
 
@@ -353,7 +355,7 @@ func TestCollectWindows(t *testing.T) {
 			screenSizeInfo: "regular",
 
 			logs: map[slog.Level]uint{
-				slog.LevelWarn: 6,
+				slog.LevelWarn: 9,
 			},
 		},
 
@@ -482,8 +484,10 @@ func TestCollectWindows(t *testing.T) {
 			}
 			require.NoError(t, err, "Collect should not return an error")
 
-			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
-			assert.Equal(t, want, got, "Collect should return expected sys information")
+			sGot, err := yaml.Marshal(got)
+			require.NoError(t, err, "Failed to marshal sysinfo to yaml")
+			want := testutils.LoadWithUpdateFromGolden(t, string(sGot))
+			assert.Equal(t, strings.ReplaceAll(want, "\r\n", "\n"), string(sGot), "Collect should return expected sys information")
 
 			if !l.AssertLevels(t, tc.logs) {
 				l.OutputLogs(t)
@@ -862,56 +866,284 @@ func TestFakeDiskInfo(_ *testing.T) {
 		fmt.Println(`
 
 ConfigManagerErrorCode      : 0
-LastErrorCode               :
-NeedsCleaning               :
+LastErrorCode               : 
+NeedsCleaning               : 
 Status                      : OK
-DeviceID                    : \\.\PHYSICALDRIVE0
-StatusInfo                  :
-Partitions                  : 4
+DeviceID                    : \\.\PHYSICALDRIVE3
+StatusInfo                  : 
+Partitions                  : 3
 BytesPerSector              : 512
 ConfigManagerUserConfig     : False
-DefaultBlockSize            :
-Index                       : 0
-InstallDate                 :
+DefaultBlockSize            : 
+Index                       : 3
+InstallDate                 : 
 InterfaceType               : SCSI
-MaxBlockSize                :
-MaxMediaSize                :
-MinBlockSize                :
-NumberOfMediaSupported      :
+MaxBlockSize                : 
+MaxMediaSize                : 
+MinBlockSize                : 
+NumberOfMediaSupported      : 
 SectorsPerTrack             : 63
-Size                        : 2000396321280
-TotalCylinders              : 243201
+Size                        : 12345
+TotalCylinders              : 12345
 TotalHeads                  : 255
-TotalSectors                : 3907024065
-TotalTracks                 : 62016255
+TotalSectors                : 1953520065
+TotalTracks                 : 31008255
 TracksPerCylinder           : 255
-Caption                     : WD Green SN350 2TB
+Caption                     : REDACTED SSD
 Description                 : Disk drive
-Name                        : \\.\PHYSICALDRIVE0
-Availability                :
+Name                        : \\.\PHYSICALDRIVE3
+Availability                : 
 CreationClassName           : Win32_DiskDrive
-ErrorCleared                :
-ErrorDescription            :
-PNPDeviceID                 : SCSI\DISK&VEN_NVME&PROD_WD_GREEN_SN350_2\5&CD81A53&0&000000
-PowerManagementCapabilities :
-PowerManagementSupported    :
+ErrorCleared                : 
+ErrorDescription            : 
+PNPDeviceID                 : REDACTED
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
 SystemCreationClassName     : Win32_ComputerSystem
-SystemName                  : MSI
+SystemName                  : REDACTED SYSTEM NAME
 Capabilities                : {3, 4}
 CapabilityDescriptions      : {Random Access, Supports Writing}
-CompressionMethod           :
-ErrorMethodology            :
-FirmwareRevision            : 33006000
+CompressionMethod           : 
+ErrorMethodology            : 
+FirmwareRevision            : REDACTED
 Manufacturer                : (Standard disk drives)
 MediaLoaded                 : True
 MediaType                   : Fixed hard disk media
-Model                       : WD Green SN350 2TB
+Model                       : REDACTED SSD MODEL
 SCSIBus                     : 0
 SCSILogicalUnit             : 0
-SCSIPort                    : 1
+SCSIPort                    : 3
 SCSITargetId                : 0
-SerialNumber                : DEAD_BEEF_D34D_B33F_DEAD_B33F_D34D_BEEF.
-Signature                   :`)
+SerialNumber                : REDACTED SERIAL NUMBER.
+Signature                   : 
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskDrive
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
+
+ConfigManagerErrorCode      : 0
+LastErrorCode               : 
+NeedsCleaning               : 
+Status                      : OK
+DeviceID                    : \\.\PHYSICALDRIVE4
+StatusInfo                  : 
+Partitions                  : 1
+BytesPerSector              : 512
+ConfigManagerUserConfig     : False
+DefaultBlockSize            : 
+Index                       : 4
+InstallDate                 : 
+InterfaceType               : SCSI
+MaxBlockSize                : 
+MaxMediaSize                : 
+MinBlockSize                : 
+NumberOfMediaSupported      : 
+SectorsPerTrack             : 63
+Size                        : 536864025600
+TotalCylinders              : 65270
+TotalHeads                  : 255
+TotalSectors                : 1048562550
+TotalTracks                 : 16643850
+TracksPerCylinder           : 255
+Caption                     : Microsoft Virtual Disk
+Description                 : Disk drive
+Name                        : \\.\PHYSICALDRIVE4
+Availability                : 
+CreationClassName           : Win32_DiskDrive
+ErrorCleared                : 
+ErrorDescription            : 
+PNPDeviceID                 : SCSI\DISK&VEN_MSFT&PROD_VIRTUAL_DISK\
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
+SystemCreationClassName     : Win32_ComputerSystem
+SystemName                  : REDACTED SYSTEM NAME
+Capabilities                : {3, 4}
+CapabilityDescriptions      : {Random Access, Supports Writing}
+CompressionMethod           : 
+ErrorMethodology            : 
+FirmwareRevision            : 1.0
+Manufacturer                : (Standard disk drives)
+MediaLoaded                 : True
+MediaType                   : Fixed hard disk media
+Model                       : Microsoft Virtual Disk
+SCSIBus                     : 0
+SCSILogicalUnit             : 1
+SCSIPort                    : 4
+SCSITargetId                : 0
+SerialNumber                : 
+Signature                   : 
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskDrive
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
+
+ConfigManagerErrorCode      : 0
+LastErrorCode               : 
+NeedsCleaning               : 
+Status                      : OK
+DeviceID                    : \\.\PHYSICALDRIVE0
+StatusInfo                  : 
+Partitions                  : 1
+BytesPerSector              : 512
+ConfigManagerUserConfig     : False
+DefaultBlockSize            : 
+Index                       : 0
+InstallDate                 : 
+InterfaceType               : IDE
+MaxBlockSize                : 
+MaxMediaSize                : 
+MinBlockSize                : 
+NumberOfMediaSupported      : 
+SectorsPerTrack             : 63
+Size                        : 10000830067200
+TotalCylinders              : 1215865
+TotalHeads                  : 255
+TotalSectors                : 19532871225
+TotalTracks                 : 310045575
+TracksPerCylinder           : 255
+Caption                     : REDACTED
+Description                 : Disk drive
+Name                        : \\.\PHYSICALDRIVE0
+Availability                : 
+CreationClassName           : Win32_DiskDrive
+ErrorCleared                : 
+ErrorDescription            : 
+PNPDeviceID                 : REDACTED
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
+SystemCreationClassName     : Win32_ComputerSystem
+SystemName                  : REDACTED SYSTEM NAME
+Capabilities                : {3, 4}
+CapabilityDescriptions      : {Random Access, Supports Writing}
+CompressionMethod           : 
+ErrorMethodology            : 
+FirmwareRevision            : DN01
+Manufacturer                : (Standard disk drives)
+MediaLoaded                 : True
+MediaType                   : Fixed hard disk media
+Model                       : REDACTED
+SCSIBus                     : 0
+SCSILogicalUnit             : 0
+SCSIPort                    : 0
+SCSITargetId                : 0
+SerialNumber                :             REDACTED SERIAL NUMBER
+Signature                   : 
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskDrive
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
+
+ConfigManagerErrorCode      : 0
+LastErrorCode               : 
+NeedsCleaning               : 
+Status                      : OK
+DeviceID                    : \\.\PHYSICALDRIVE2
+StatusInfo                  : 
+Partitions                  : 2
+BytesPerSector              : 512
+ConfigManagerUserConfig     : False
+DefaultBlockSize            : 
+Index                       : 2
+InstallDate                 : 
+InterfaceType               : SCSI
+MaxBlockSize                : 
+MaxMediaSize                : 
+MinBlockSize                : 
+NumberOfMediaSupported      : 
+SectorsPerTrack             : 63
+Size                        : 1024203640320
+TotalCylinders              : 124519
+TotalHeads                  : 255
+TotalSectors                : 2000397735
+TotalTracks                 : 31752345
+TracksPerCylinder           : 255
+Caption                     : REDACTED
+Description                 : Disk drive
+Name                        : \\.\PHYSICALDRIVE2
+Availability                : 
+CreationClassName           : Win32_DiskDrive
+ErrorCleared                : 
+ErrorDescription            : 
+PNPDeviceID                 : REDACTED
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
+SystemCreationClassName     : Win32_ComputerSystem
+SystemName                  : REDACTED SYSTEM NAME
+Capabilities                : {3, 4}
+CapabilityDescriptions      : {Random Access, Supports Writing}
+CompressionMethod           : 
+ErrorMethodology            : 
+FirmwareRevision            : 70626000
+Manufacturer                : (Standard disk drives)
+MediaLoaded                 : True
+MediaType                   : Fixed hard disk media
+Model                       : REDACTED MODEL
+SCSIBus                     : 0
+SCSILogicalUnit             : 0
+SCSIPort                    : 2
+SCSITargetId                : 0
+SerialNumber                : REDACTED SERIAL NUMBER.
+Signature                   : 
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskDrive
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
+
+ConfigManagerErrorCode      : 0
+LastErrorCode               : 
+NeedsCleaning               : 
+Status                      : OK
+DeviceID                    : \\.\PHYSICALDRIVE1
+StatusInfo                  : 
+Partitions                  : 1
+BytesPerSector              : 512
+ConfigManagerUserConfig     : False
+DefaultBlockSize            : 
+Index                       : 1
+InstallDate                 : 
+InterfaceType               : IDE
+MaxBlockSize                : 
+MaxMediaSize                : 
+MinBlockSize                : 
+NumberOfMediaSupported      : 
+SectorsPerTrack             : 63
+Size                        : 1000202273280
+TotalCylinders              : 121601
+TotalHeads                  : 255
+TotalSectors                : 1953520065
+TotalTracks                 : 31008255
+TracksPerCylinder           : 255
+Caption                     : REDACTED
+Description                 : Disk drive
+Name                        : \\.\PHYSICALDRIVE1
+Availability                : 
+CreationClassName           : Win32_DiskDrive
+ErrorCleared                : 
+ErrorDescription            : 
+PNPDeviceID                 : REDACTED ID
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
+SystemCreationClassName     : Win32_ComputerSystem
+SystemName                  : REDACTED SYSTEM NAME
+Capabilities                : {3, 4}
+CapabilityDescriptions      : {Random Access, Supports Writing}
+CompressionMethod           : 
+ErrorMethodology            : 
+FirmwareRevision            : REDACTED FIRMWARE
+Manufacturer                : (Standard disk drives)
+MediaLoaded                 : True
+MediaType                   : Fixed hard disk media
+Model                       : REDACTED MODEL
+SCSIBus                     : 2
+SCSILogicalUnit             : 0
+SCSIPort                    : 0
+SCSITargetId                : 0
+SerialNumber                : REDACTED SERIAL NUMBER.
+Signature                   : 
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskDrive
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties`)
 	case "malicious":
 		fmt.Println(`
 
@@ -958,7 +1190,52 @@ TracksPerCylinder           : 255
 Caption                     : WD Green SN350 2TB
 Description                 : Disk drive
 Name                        : \\.\PHYSICALDRIVE0
-Model                       : WD Green SN350 2TB`)
+Model                       : WD Green SN350 2TB
+
+Partitions                  : 1
+BytesPerSector              : 512
+Index                       : -2
+SectorsPerTrack             : 63
+Size                        : 2000396321280
+TotalCylinders              : 243201
+TotalHeads                  : 255
+TotalSectors                : 3907024065
+TotalTracks                 : 62016255
+TracksPerCylinder           : 255
+Caption                     : Generic Drive
+Description                 : Disk drive
+Name                        : \\.\PHYSICALDRIVE111
+Model                       : Generic Drive
+
+Partitions                  : 1
+BytesPerSector              : 512
+Index                       : 500
+SectorsPerTrack             : 63
+Size                        : 2000396321280
+TotalCylinders              : 243201
+TotalHeads                  : 255
+TotalSectors                : 3907024065
+TotalTracks                 : 62016255
+TracksPerCylinder           : 255
+Caption                     : Generic Drive
+Description                 : Disk drive
+Name                        : \\.\PHYSICALDRIVE111
+Model                       : Generic Drive
+
+Partitions                  : 1
+BytesPerSector              : 512
+Index                       : 3
+SectorsPerTrack             : 63
+Size                        : Not a Number
+TotalCylinders              : 243201
+TotalHeads                  : 255
+TotalSectors                : 3907024065
+TotalTracks                 : 62016255
+TracksPerCylinder           : 255
+Caption                     : Generic Drive
+Description                 : Disk drive
+Name                        : \\.\PHYSICALDRIVE111
+Model                       : Generic Drive`)
 	case "":
 		fallthrough
 	case "missing":
@@ -981,144 +1258,316 @@ func TestFakePartitionInfo(_ *testing.T) {
 		fmt.Println(`
 
 Index                       : 0
-Status                      :
-StatusInfo                  :
-Name                        : Disk #0, Partition #0
-Caption                     : Disk #0, Partition #0
+Status                      : 
+StatusInfo                  : 
+Name                        : Disk #3, Partition #0
+Caption                     : Disk #3, Partition #0
 Description                 : GPT: System
-InstallDate                 :
-Availability                :
-ConfigManagerErrorCode      :
-ConfigManagerUserConfig     :
+InstallDate                 : 
+Availability                : 
+ConfigManagerErrorCode      : 
+ConfigManagerUserConfig     : 
 CreationClassName           : Win32_DiskPartition
-DeviceID                    : Disk #0, Partition #0
-ErrorCleared                :
-ErrorDescription            :
-LastErrorCode               :
-PNPDeviceID                 :
-PowerManagementCapabilities :
-PowerManagementSupported    :
+DeviceID                    : Disk #3, Partition #0
+ErrorCleared                : 
+ErrorDescription            : 
+LastErrorCode               : 
+PNPDeviceID                 : 
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
 SystemCreationClassName     : Win32_ComputerSystem
-SystemName                  : MSI
-Access                      :
+SystemName                  : REDACTED SYSTEM NAME
+Access                      : 
 BlockSize                   : 512
-ErrorMethodology            :
-NumberOfBlocks              : 614400
-Purpose                     :
+ErrorMethodology            : 
+NumberOfBlocks              : 204800
+Purpose                     : 
 Bootable                    : True
 PrimaryPartition            : True
 BootPartition               : True
-DiskIndex                   : 0
-HiddenSectors               :
-RewritePartition            :
-Size                        : 314572800
+DiskIndex                   : 3
+HiddenSectors               : 
+RewritePartition            : 
+Size                        : 104857600
 StartingOffset              : 1048576
 Type                        : GPT: System
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskPartition
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
 
 Index                       : 1
-Status                      :
-StatusInfo                  :
-Name                        : Disk #0, Partition #1
-Caption                     : Disk #0, Partition #1
-Description                 : GPT: Unknown
-InstallDate                 :
-Availability                :
-ConfigManagerErrorCode      :
-ConfigManagerUserConfig     :
+Status                      : 
+StatusInfo                  : 
+Name                        : Disk #3, Partition #1
+Caption                     : Disk #3, Partition #1
+Description                 : GPT: Basic Data
+InstallDate                 : 
+Availability                : 
+ConfigManagerErrorCode      : 
+ConfigManagerUserConfig     : 
 CreationClassName           : Win32_DiskPartition
-DeviceID                    : Disk #0, Partition #1
-ErrorCleared                :
-ErrorDescription            :
-LastErrorCode               :
-PNPDeviceID                 :
-PowerManagementCapabilities :
-PowerManagementSupported    :
+DeviceID                    : Disk #3, Partition #1
+ErrorCleared                : 
+ErrorDescription            : 
+LastErrorCode               : 
+PNPDeviceID                 : 
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
 SystemCreationClassName     : Win32_ComputerSystem
-SystemName                  : MSI
-Access                      :
+SystemName                  : REDACTED SYSTEM NAME
+Access                      : 
 BlockSize                   : 512
-ErrorMethodology            :
-NumberOfBlocks              : 1843200
-Purpose                     :
+ErrorMethodology            : 
+NumberOfBlocks              : 1951709184
+Purpose                     : 
 Bootable                    : False
-PrimaryPartition            : False
+PrimaryPartition            : True
 BootPartition               : False
-DiskIndex                   : 0
-HiddenSectors               :
-RewritePartition            :
-Size                        : 943718400
-StartingOffset              : 449839104
-Type                        : GPT: Unknown
+DiskIndex                   : 3
+HiddenSectors               : 
+RewritePartition            : 
+Size                        : 999275102208
+StartingOffset              : 122683392
+Type                        : GPT: Basic Data
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskPartition
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
 
 Index                       : 2
-Status                      :
-StatusInfo                  :
-Name                        : Disk #0, Partition #2
-Caption                     : Disk #0, Partition #2
+Status                      : 
+StatusInfo                  : 
+Name                        : Disk #3, Partition #2
+Caption                     : Disk #3, Partition #2
 Description                 : GPT: Unknown
-InstallDate                 :
-Availability                :
-ConfigManagerErrorCode      :
-ConfigManagerUserConfig     :
+InstallDate                 : 
+Availability                : 
+ConfigManagerErrorCode      : 
+ConfigManagerUserConfig     : 
 CreationClassName           : Win32_DiskPartition
-DeviceID                    : Disk #0, Partition #2
-ErrorCleared                :
-ErrorDescription            :
-LastErrorCode               :
-PNPDeviceID                 :
-PowerManagementCapabilities :
-PowerManagementSupported    :
+DeviceID                    : Disk #3, Partition #2
+ErrorCleared                : 
+ErrorDescription            : 
+LastErrorCode               : 
+PNPDeviceID                 : 
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
 SystemCreationClassName     : Win32_ComputerSystem
-SystemName                  : MSI
-Access                      :
+SystemName                  : REDACTED SYSTEM NAME
+Access                      : 
 BlockSize                   : 512
-ErrorMethodology            :
-NumberOfBlocks              : 43268096
-Purpose                     :
+ErrorMethodology            : 
+NumberOfBlocks              : 1572864
+Purpose                     : 
 Bootable                    : False
 PrimaryPartition            : False
 BootPartition               : False
-DiskIndex                   : 0
-HiddenSectors               :
-RewritePartition            :
-Size                        : 22153265152
-StartingOffset              : 1393557504
+DiskIndex                   : 3
+HiddenSectors               : 
+RewritePartition            : 
+Size                        : 805306368
+StartingOffset              : 999397785600
 Type                        : GPT: Unknown
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskPartition
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
 
-Index                       : 3
-Status                      :
-StatusInfo                  :
-Name                        : Disk #0, Partition #3
-Caption                     : Disk #0, Partition #3
+Index                       : 0
+Status                      : 
+StatusInfo                  : 
+Name                        : Disk #4, Partition #0
+Caption                     : Disk #4, Partition #0
 Description                 : GPT: Basic Data
-InstallDate                 :
-Availability                :
-ConfigManagerErrorCode      :
-ConfigManagerUserConfig     :
+InstallDate                 : 
+Availability                : 
+ConfigManagerErrorCode      : 
+ConfigManagerUserConfig     : 
 CreationClassName           : Win32_DiskPartition
-DeviceID                    : Disk #0, Partition #3
-ErrorCleared                :
-ErrorDescription            :
-LastErrorCode               :
-PNPDeviceID                 :
-PowerManagementCapabilities :
-PowerManagementSupported    :
+DeviceID                    : Disk #4, Partition #0
+ErrorCleared                : 
+ErrorDescription            : 
+LastErrorCode               : 
+PNPDeviceID                 : 
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
 SystemCreationClassName     : Win32_ComputerSystem
-SystemName                  : MSI
-Access                      :
+SystemName                  : REDACTED SYSTEM NAME
+Access                      : 
 BlockSize                   : 512
-ErrorMethodology            :
-NumberOfBlocks              : 3861037056
-Purpose                     :
+ErrorMethodology            : 
+NumberOfBlocks              : 1048541184
+Purpose                     : 
+Bootable                    : False
+PrimaryPartition            : True
+BootPartition               : False
+DiskIndex                   : 4
+HiddenSectors               : 
+RewritePartition            : 
+Size                        : 536853086208
+StartingOffset              : 16777216
+Type                        : GPT: Basic Data
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskPartition
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
+
+Index                       : 0
+Status                      : 
+StatusInfo                  : 
+Name                        : Disk #0, Partition #0
+Caption                     : Disk #0, Partition #0
+Description                 : GPT: Basic Data
+InstallDate                 : 
+Availability                : 
+ConfigManagerErrorCode      : 
+ConfigManagerUserConfig     : 
+CreationClassName           : Win32_DiskPartition
+DeviceID                    : Disk #0, Partition #0
+ErrorCleared                : 
+ErrorDescription            : 
+LastErrorCode               : 
+PNPDeviceID                 : 
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
+SystemCreationClassName     : Win32_ComputerSystem
+SystemName                  : REDACTED SYSTEM NAME
+Access                      : 
+BlockSize                   : 512
+ErrorMethodology            : 
+NumberOfBlocks              : 19532869632
+Purpose                     : 
 Bootable                    : False
 PrimaryPartition            : True
 BootPartition               : False
 DiskIndex                   : 0
-HiddenSectors               :
-RewritePartition            :
-Size                        : 1976850972672
-StartingOffset              : 23546822656
-Type                        : GPT: Basic Data`)
+HiddenSectors               : 
+RewritePartition            : 
+Size                        : 10000829251584
+StartingOffset              : 1048576
+Type                        : GPT: Basic Data
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskPartition
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
+
+Index                       : 0
+Status                      : 
+StatusInfo                  : 
+Name                        : Disk #2, Partition #0
+Caption                     : Disk #2, Partition #0
+Description                 : GPT: System
+InstallDate                 : 
+Availability                : 
+ConfigManagerErrorCode      : 
+ConfigManagerUserConfig     : 
+CreationClassName           : Win32_DiskPartition
+DeviceID                    : Disk #2, Partition #0
+ErrorCleared                : 
+ErrorDescription            : 
+LastErrorCode               : 
+PNPDeviceID                 : 
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
+SystemCreationClassName     : Win32_ComputerSystem
+SystemName                  : REDACTED SYSTEM NAME
+Access                      : 
+BlockSize                   : 512
+ErrorMethodology            : 
+NumberOfBlocks              : 2201600
+Purpose                     : 
+Bootable                    : True
+PrimaryPartition            : True
+BootPartition               : True
+DiskIndex                   : 2
+HiddenSectors               : 
+RewritePartition            : 
+Size                        : 1127219200
+StartingOffset              : 1048576
+Type                        : GPT: System
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskPartition
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
+
+Index                       : 1
+Status                      : 
+StatusInfo                  : 
+Name                        : Disk #2, Partition #1
+Caption                     : Disk #2, Partition #1
+Description                 : GPT: Unknown
+InstallDate                 : 
+Availability                : 
+ConfigManagerErrorCode      : 
+ConfigManagerUserConfig     : 
+CreationClassName           : Win32_DiskPartition
+DeviceID                    : Disk #2, Partition #1
+ErrorCleared                : 
+ErrorDescription            : 
+LastErrorCode               : 
+PNPDeviceID                 : 
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
+SystemCreationClassName     : Win32_ComputerSystem
+SystemName                  : REDACTED SYSTEM NAME
+Access                      : 
+BlockSize                   : 512
+ErrorMethodology            : 
+NumberOfBlocks              : 1998204928
+Purpose                     : 
+Bootable                    : False
+PrimaryPartition            : False
+BootPartition               : False
+DiskIndex                   : 2
+HiddenSectors               : 
+RewritePartition            : 
+Size                        : 1023080923136
+StartingOffset              : 1128267776
+Type                        : GPT: Unknown
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskPartition
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties
+
+Index                       : 0
+Status                      : 
+StatusInfo                  : 
+Name                        : Disk #1, Partition #0
+Caption                     : Disk #1, Partition #0
+Description                 : GPT: Basic Data
+InstallDate                 : 
+Availability                : 
+ConfigManagerErrorCode      : 
+ConfigManagerUserConfig     : 
+CreationClassName           : Win32_DiskPartition
+DeviceID                    : Disk #1, Partition #0
+ErrorCleared                : 
+ErrorDescription            : 
+LastErrorCode               : 
+PNPDeviceID                 : 
+PowerManagementCapabilities : 
+PowerManagementSupported    : 
+SystemCreationClassName     : Win32_ComputerSystem
+SystemName                  : REDACTED SYSTEM NAME
+Access                      : 
+BlockSize                   : 512
+ErrorMethodology            : 
+NumberOfBlocks              : 1953488896
+Purpose                     : 
+Bootable                    : False
+PrimaryPartition            : True
+BootPartition               : False
+DiskIndex                   : 1
+HiddenSectors               : 
+RewritePartition            : 
+Size                        : 1000186314752
+StartingOffset              : 16777216
+Type                        : GPT: Basic Data
+PSComputerName              : 
+CimClass                    : root/cimv2:Win32_DiskPartition
+CimInstanceProperties       : {Caption, Description, InstallDate, Name…}
+CimSystemProperties         : Microsoft.Management.Infrastructure.CimSystemProperties`)
 	case "malicious":
 		fmt.Println(`
 
@@ -1150,7 +1599,22 @@ Size                        : 22153265152
 Index                       : 2
 Name                        : Disk beta, Partition #2
 DiskIndex                   : beta
-Size                        : 1976850972672`)
+Size                        : 1976850972672
+
+Index                       : 500
+Name                        : Disk 1, Partition #500
+DiskIndex                   : 1
+Size                        : 1976850972672
+
+Index                       : 3
+Name                        : Disk #0, Partition #3
+DiskIndex                   : 0
+Size                        : -20
+
+Index                       : 3
+Name                        : Disk #500, Partition #0
+DiskIndex                   : 500
+Size                        : -20`)
 	case "":
 		fallthrough
 	case "missing":

--- a/internal/collector/sysinfo/hardware/hardware_windows_test.go
+++ b/internal/collector/sysinfo/hardware/hardware_windows_test.go
@@ -307,7 +307,7 @@ func TestCollectWindows(t *testing.T) {
 			screenSizeInfo: "regular",
 
 			logs: map[slog.Level]uint{
-				slog.LevelWarn: 12,
+				slog.LevelWarn: 13,
 			},
 		},
 
@@ -1234,6 +1234,21 @@ TotalTracks                 : 62016255
 TracksPerCylinder           : 255
 Caption                     : Generic Drive
 Description                 : Disk drive
+Name                        : \\.\PHYSICALDRIVE111
+Model                       : Generic Drive
+
+Partitions                  : 1
+BytesPerSector              : 512
+Index                       : 0
+SectorsPerTrack             : 63
+Size                        : 2000396321280
+TotalCylinders              : 243201
+TotalHeads                  : 255
+TotalSectors                : 3907024065
+TotalTracks                 : 62016255
+TracksPerCylinder           : 255
+Caption                     : Generic Drive
+Description                 : Duplicate disk
 Name                        : \\.\PHYSICALDRIVE111
 Model                       : Generic Drive`)
 	case "":

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/bad_memory_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/bad_memory_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 0
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_cpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_cpu_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_gpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_gpu_information
@@ -14,15 +14,31 @@ gpus: []
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_memory_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_memory_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 0
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_partition_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_partition_information
@@ -20,7 +20,21 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
+      partitions:
+        - size: 0
+          partitions: []
+    - size: 953867
+      partitions:
+        - size: 0
+          partitions: []
+    - size: 976756
+      partitions:
+        - size: 0
+          partitions: []
+        - size: 0
+          partitions: []
+    - size: 0
       partitions:
         - size: 0
           partitions: []
@@ -28,6 +42,8 @@ blks:
           partitions: []
         - size: 0
           partitions: []
+    - size: 511993
+      partitions:
         - size: 0
           partitions: []
 screens:

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_product_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_product_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_screen_resolution_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_screen_resolution_information
@@ -20,14 +20,30 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens: []

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_screen_size_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/error_screen_size_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/garbage_memory_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/garbage_memory_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 0
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/malicious_disk_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/malicious_disk_information
@@ -22,13 +22,13 @@ mem:
 blks:
     - size: 1907726
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+        - size: 0
           partitions: []
-        - size: 21127
+        - size: 0
           partitions: []
-        - size: 1885272
+        - size: 0
           partitions: []
         - size: 0
           partitions: []
@@ -281,6 +281,14 @@ blks:
     - size: 1907726
       partitions: []
     - size: 1907726
+      partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+    - size: 0
+      partitions: []
+    - size: 0
       partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/malicious_disk_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/malicious_disk_information
@@ -290,6 +290,8 @@ blks:
       partitions: []
     - size: 0
       partitions: []
+    - size: 0
+      partitions: []
 screens:
     - name: Default Monitor
       physicalresolution: ""

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/malicious_partition_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/malicious_partition_information
@@ -20,7 +20,21 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
+      partitions:
+        - size: 0
+          partitions: []
+    - size: 953867
+      partitions:
+        - size: 0
+          partitions: []
+    - size: 976756
+      partitions:
+        - size: 0
+          partitions: []
+        - size: 0
+          partitions: []
+    - size: 0
       partitions:
         - size: 0
           partitions: []
@@ -28,6 +42,8 @@ blks:
           partitions: []
         - size: 0
           partitions: []
+    - size: 511993
+      partitions:
         - size: 0
           partitions: []
 screens:

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_cpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_cpu_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_gpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_gpu_information
@@ -14,15 +14,31 @@ gpus: []
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_memory_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_memory_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 0
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_partition_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_partition_information
@@ -20,7 +20,21 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
+      partitions:
+        - size: 0
+          partitions: []
+    - size: 953867
+      partitions:
+        - size: 0
+          partitions: []
+    - size: 976756
+      partitions:
+        - size: 0
+          partitions: []
+        - size: 0
+          partitions: []
+    - size: 0
       partitions:
         - size: 0
           partitions: []
@@ -28,6 +42,8 @@ blks:
           partitions: []
         - size: 0
           partitions: []
+    - size: 511993
+      partitions:
         - size: 0
           partitions: []
 screens:

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_product_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_product_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_screen_resolution_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_screen_resolution_information
@@ -20,14 +20,30 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens: []

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_screen_size_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/missing_screen_size_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/negative_memory_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/negative_memory_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 0
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/negative_valued_cpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/negative_valued_cpu_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/regular_hardware_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/regular_hardware_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/zero_valued_cpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/zero_valued_cpu_information
@@ -20,15 +20,31 @@ gpus:
 mem:
     total: 65237
 blks:
-    - size: 1907726
+    - size: 9537534
       partitions:
-        - size: 300
+        - size: 9537534
           partitions: []
-        - size: 900
+    - size: 953867
+      partitions:
+        - size: 953852
           partitions: []
-        - size: 21127
+    - size: 976756
+      partitions:
+        - size: 1075
           partitions: []
-        - size: 1885272
+        - size: 975686
+          partitions: []
+    - size: 0
+      partitions:
+        - size: 100
+          partitions: []
+        - size: 952983
+          partitions: []
+        - size: 768
+          partitions: []
+    - size: 511993
+      partitions:
+        - size: 511983
           partitions: []
 screens:
     - name: Default Monitor


### PR DESCRIPTION
Fix windows disk partition collection to remove the assumption that disks are printed in order of their indices. 
Added additional tests.

---
UDENG-6500