### PR TITLE
fix(hardware_linux): Remove physical resolution field from Linux reports

### DIFF
--- a/internal/collector/sysinfo/hardware/hardware_linux.go
+++ b/internal/collector/sysinfo/hardware/hardware_linux.go
@@ -418,8 +418,7 @@ func (h Collector) collectScreens(pi platform.Info) (info []screen, err error) {
 		}
 
 		info = append(info, screen{
-			PhysicalResolution: header[3],
-			Size:               header[4],
+			Size: header[4],
 
 			Resolution:  v[1],
 			RefreshRate: v[2],

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/bad_block_nesting_depth
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/bad_block_nesting_depth
@@ -56,11 +56,11 @@ blks:
                                               type: disk
                                               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/cpu_information_with_negative_values_is_handled
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/cpu_information_with_negative_values_is_handled
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_block_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_block_information
@@ -23,11 +23,11 @@ mem:
     total: 31941
 blks: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_cpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_cpu_information
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_block_information_is_empty
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_block_information_is_empty
@@ -23,11 +23,11 @@ mem:
     total: 31941
 blks: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_cpu_information_is_empty
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_cpu_information_is_empty
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_block_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_block_information
@@ -23,11 +23,11 @@ mem:
     total: 31941
 blks: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_cpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_cpu_information
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_gpu_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_gpu_information
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_gpus
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_gpus
@@ -45,11 +45,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_memory_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_memory_information
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_product_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_product_information
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/regular_hardware_information
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/regular_hardware_information
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/some_cpu_information_is_derived_when_missing
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/some_cpu_information_is_derived_when_missing
@@ -53,11 +53,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wsl_hardware_information_with_xrandr
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wsl_hardware_information_with_xrandr
@@ -45,11 +45,11 @@ blks:
               type: part
               children: []
 screens:
-    - physicalresolution: 3840x2160
+    - physicalresolution: ""
       size: 598mm x 336mm
       resolution: 1920x1080
       refreshrate: "60.00"
-    - physicalresolution: 3072x1728
+    - physicalresolution: ""
       size: 344mm x 193mm
       resolution: 1920x1080
       refreshrate: "60.03"


### PR DESCRIPTION
On Linux, to get screen information, xrandr is currently being used. While this seems acceptable for most cases, including when the backend is Wayland, it does not provide the correct physical resolution, and only provides post-scaling resolution. Thus, for now, the report should not include possibly false physical resolution.

---
[UDENG-6569](https://warthogs.atlassian.net/browse/UDENG-6569)

[UDENG-6569]: https://warthogs.atlassian.net/browse/UDENG-6569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ