### PR TITLE
feat(cmd): Implement go generation for completion scripts and man pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # Built CLI-executable binary
 cmd/insights/insights
+
+generated

--- a/cmd/generate_completion_documentation.go
+++ b/cmd/generate_completion_documentation.go
@@ -1,0 +1,177 @@
+// TiCS: disabled // This is generating completion and doc, not production code.
+
+//go:build tools
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	"github.com/ubuntu/ubuntu-insights/cmd/insights/commands"
+)
+
+const usage = `Usage of %s:
+
+   completion DIRECTORY
+     Create completions files in a structured hierarchy in DIRECTORY.
+   man DIRECTORY
+     Create man pages files in a structured hierarchy in DIRECTORY.
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf(usage, os.Args[0])
+	}
+	i, err := commands.New()
+	if err != nil {
+		log.Fatalf("Couldn't create new command: %v", err)
+	}
+
+	commands := []cobra.Command{i.RootCmd()}
+
+	if len(os.Args) < 3 {
+		log.Fatalf(usage, os.Args[0])
+	}
+	dir := filepath.Join(os.Args[2], "usr", "share")
+	switch os.Args[1] {
+	case "completion":
+		genCompletions(commands, dir)
+	case "man":
+		genManPages(commands, dir)
+	default:
+		log.Fatalf(usage, os.Args[0])
+	}
+}
+
+// genCompletions for bash and zsh directories
+func genCompletions(cmds []cobra.Command, dir string) {
+	bashCompDir := filepath.Join(dir, "bash-completion", "completions")
+	zshCompDir := filepath.Join(dir, "zsh", "site-functions")
+	for _, d := range []string{bashCompDir, zshCompDir} {
+		if err := cleanDirectory(filepath.Dir(d)); err != nil {
+			log.Fatalln(err)
+		}
+		if err := createDirectory(d, 0755); err != nil {
+			log.Fatalf("Couldn't create bash completion directory: %v", err)
+		}
+	}
+
+	for _, cmd := range cmds {
+		if err := cmd.GenBashCompletionFileV2(filepath.Join(bashCompDir, cmd.Name()), true); err != nil {
+			log.Fatalf("Couldn't create bash completion for %s: %v", cmd.Name(), err)
+		}
+		if err := cmd.GenZshCompletionFile(filepath.Join(zshCompDir, cmd.Name())); err != nil {
+			log.Fatalf("Couldn't create zsh completion for %s: %v", cmd.Name(), err)
+		}
+	}
+}
+
+func genManPages(cmds []cobra.Command, dir string) {
+	manBaseDir := filepath.Join(dir, "man")
+	if err := cleanDirectory(manBaseDir); err != nil {
+		log.Fatalln(err)
+	}
+
+	out := filepath.Join(manBaseDir, "man1")
+	if err := createDirectory(out, 0755); err != nil {
+		log.Fatalf("Couldn't create man pages directory: %v", err)
+	}
+
+	for _, cmd := range cmds {
+		cmd := cmd
+		// Run ExecuteC to install completion and help commands
+		_, _ = cmd.ExecuteC()
+		opts := doc.GenManTreeOptions{
+			Header: &doc.GenManHeader{
+				Title: fmt.Sprintf("Ubuntu-insights: %s", cmd.Name()),
+			},
+			Path: out,
+		}
+		if err := genManTreeFromOpts(&cmd, opts); err != nil {
+			log.Fatalf("Couldn't generate man pages for %s: %v", cmd.Name(), err)
+		}
+	}
+}
+
+func mustWriteLine(w io.Writer, msg string) {
+	if _, err := w.Write([]byte(msg + "\n")); err != nil {
+		log.Fatalf("Couldn't write %s: %v", msg, err)
+	}
+}
+
+// genManTreeFromOpts generates a man page for the command and all descendants.
+// The pages are written to the opts.Path directory.
+// This is a copy from cobra, but it will include Hidden commands.
+func genManTreeFromOpts(cmd *cobra.Command, opts doc.GenManTreeOptions) error {
+	header := opts.Header
+	if header == nil {
+		header = &doc.GenManHeader{}
+	}
+	for _, c := range cmd.Commands() {
+		if (!c.IsAvailableCommand() && !c.Hidden) || c.IsAdditionalHelpTopicCommand() {
+			continue
+		}
+		if err := genManTreeFromOpts(c, opts); err != nil {
+			return err
+		}
+	}
+	section := "1"
+	if header.Section != "" {
+		section = header.Section
+	}
+
+	separator := "_"
+	if opts.CommandSeparator != "" {
+		separator = opts.CommandSeparator
+	}
+	basename := strings.Replace(cmd.CommandPath(), " ", separator, -1)
+	filename := filepath.Join(opts.Path, basename+"."+section)
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	headerCopy := *header
+	return doc.GenMan(cmd, &headerCopy, f)
+}
+
+// cleanDirectory removes a directory and recreates it.
+func cleanDirectory(p string) error {
+	if err := os.RemoveAll(p); err != nil {
+		return fmt.Errorf("couldn't delete %q: %w", p, err)
+	}
+	if err := createDirectory(p, 0750); err != nil {
+		return fmt.Errorf("couldn't create %q: %w", p, err)
+	}
+	return nil
+}
+
+// createDirectory creates a directory with the given permissions.
+// If the directory already exists, it is left untouched.
+// If the directory cannot be created, an error is returned.
+//
+// Prefer this way of creating directories instead of os.Mkdir as the latter
+// could bypass fakeroot and cause unexpected confusion.
+//
+// The additional os.MkdirAll is for compatibility with Windows.
+func createDirectory(dir string, perm uint32) error {
+	// First attempt with os.MkdirAll
+	if err := os.MkdirAll(dir, os.FileMode(perm)); err != nil {
+		// #nosec:G204 - we control the mode and directory we run mkdir on
+		cmd := exec.Command("mkdir", "-m", fmt.Sprintf("%o", perm), "-p", dir)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("Couldn't create dest directory: %v", string(output))
+		}
+	}
+
+	return nil
+}

--- a/cmd/insights/commands/root.go
+++ b/cmd/insights/commands/root.go
@@ -151,3 +151,8 @@ func (a *App) Run() error {
 func (a App) UsageError() bool {
 	return !a.cmd.SilenceUsage
 }
+
+// RootCmd returns the root command.
+func (a App) RootCmd() cobra.Command {
+	return *a.cmd
+}

--- a/cmd/insights/commands/root_test.go
+++ b/cmd/insights/commands/root_test.go
@@ -74,3 +74,13 @@ func TestUsageError(t *testing.T) {
 	app.cmd.SilenceUsage = false
 	assert.True(t, app.UsageError())
 }
+
+func TestRootCmd(t *testing.T) {
+	app, err := New()
+	require.NoError(t, err)
+
+	cmd := app.RootCmd()
+
+	assert.NotNil(t, cmd, "Returned root cmd should not be nil")
+	assert.Equal(t, constants.CmdName, cmd.Name())
+}

--- a/cmd/insights/main.go
+++ b/cmd/insights/main.go
@@ -9,6 +9,9 @@ import (
 	"github.com/ubuntu/ubuntu-insights/internal/constants"
 )
 
+//go:generate go run ../generate_completion_documentation.go completion ../../generated
+//go:generate go run -ldflags=-X=github.com/ubuntu/ubuntu-insights/internal/constants.manGeneration=true ../generate_completion_documentation.go man ../../generated
+
 func main() {
 	slog.SetLogLoggerLevel(constants.DefaultLogLevel)
 

--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,14 @@ require (
 )
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -29,6 +30,7 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -12,6 +12,9 @@ import (
 var (
 	// Version is the version of the application.
 	Version = "Dev"
+
+	// manGeneration is whenever or not man pages are being generated.
+	manGeneration = "false"
 )
 
 const (
@@ -53,6 +56,14 @@ var (
 )
 
 func init() {
+	// This is to ensure that the man pages which include the default values
+	// are not generated with the home path at time of generation.
+	if manGeneration == "true" {
+		DefaultConfigPath = ""
+		DefaultCachePath = ""
+		return
+	}
+
 	userConfigDir, err := os.UserConfigDir()
 	if err != nil {
 		panic(fmt.Sprintf("Could not fetch config directory: %v", err))


### PR DESCRIPTION
Implement go generation for completion scripts and man pages, while ensuring that the paths for the static man pages are do not depend on the home path at the time of generation.

Implemented with deb packaging in mind.

---
[UDENG-6603](https://warthogs.atlassian.net/browse/UDENG-6603)


[UDENG-6603]: https://warthogs.atlassian.net/browse/UDENG-6603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ