### PR TITLE
fix(systemd): Modifications for systemd units

### DIFF
--- a/autostart/systemd/ubuntu-insights-collect.service
+++ b/autostart/systemd/ubuntu-insights-collect.service
@@ -2,7 +2,7 @@
 Description="Collect platform report using Ubuntu Insights while respecting consent."
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/bin/ubuntu-insights collect -p=2629743
 Restart=no
 Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/mnt/c/WINDOWS/system32"

--- a/autostart/systemd/ubuntu-insights-collect.timer
+++ b/autostart/systemd/ubuntu-insights-collect.timer
@@ -4,7 +4,7 @@ Description="Run Ubuntu-Insights collects 5 mins after boot and every month rela
 [Timer]
 OnBootSec=5min
 OnUnitActiveSec=1months
-Unit=ubuntu-insights-collect.service
+Unit=ubuntu-insights-collect
 
 [Install]
 WantedBy=timers.target

--- a/autostart/systemd/ubuntu-insights-upload.service
+++ b/autostart/systemd/ubuntu-insights-upload.service
@@ -2,7 +2,7 @@
 Description="Upload collected and mature platform report using Ubuntu Insights while respecting consent."
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/bin/ubuntu-insights upload -r
 Restart=no
 SuccessExitStatus=1

--- a/autostart/systemd/ubuntu-insights-upload.timer
+++ b/autostart/systemd/ubuntu-insights-upload.timer
@@ -2,9 +2,9 @@
 Description="Run Ubuntu-Insights upload 5 mins after boot and every week relative to the activation time"
 
 [Timer]
-OnBootSec=5min
+OnBootSec=8min
 OnUnitActiveSec=1weeks
-Unit=ubuntu-insights-upload.service
+Unit=ubuntu-insights-upload
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
 A few modifications for the systemd units.
 
 - `ubuntu-insights-collect.service`: Type=simple. Make this oneshot
 - `ubuntu-insights-collect.timer`: `Unit=ubuntu-insights-collect.service` -> drop the .service
 - `ubuntu-insights-upload.service`: Type: Make this oneshot
 - `ubuntu-insights-upload.timer`: Adjust the timer to trigger slightly after collection; drop the .service
---
[UDENG-6602](https://warthogs.atlassian.net/browse/UDENG-6602)

[UDENG-6602]: https://warthogs.atlassian.net/browse/UDENG-6602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ