### PR TITLE
fix(hardware): Fix Windows single disk and single partition collection

### DIFF
--- a/internal/collector/sysinfo/hardware/hardware_windows_test.go
+++ b/internal/collector/sysinfo/hardware/hardware_windows_test.go
@@ -295,6 +295,23 @@ func TestCollectWindows(t *testing.T) {
 			},
 		},
 
+		"Single disk and part": {
+			productInfo:   "regular",
+			cpuInfo:       "regular",
+			gpuInfo:       "regular",
+			memoryInfo:    "regular",
+			diskInfo:      "single",
+			partitionInfo: "single",
+
+			screenResInfo:     "regular",
+			screenPhysResInfo: "regular",
+			screenSizeInfo:    "regular",
+
+			logs: map[slog.Level]uint{
+				slog.LevelInfo: 1,
+			},
+		},
+
 		"Missing disk information": {
 			productInfo:   "regular",
 			cpuInfo:       "regular",
@@ -1138,6 +1155,14 @@ func TestFakeDiskInfo(_ *testing.T) {
     "Partitions": 1
   }
 ]`)
+	case "single":
+		fmt.Println(`
+{
+		  "MediaType": "Fixed hard disk media",
+		  "Index": 0,
+		  "Size": 1000202273280,
+		  "Partitions": 1
+}`)
 	case "malicious":
 		fmt.Println(`
 [
@@ -1263,6 +1288,13 @@ func TestFakePartitionInfo(_ *testing.T) {
     "Type": "GPT: Basic Data"
   }
 ]`)
+	case "single":
+		fmt.Println(`
+{
+		  "DiskIndex": 0,
+		  "Size": 104857600,
+		  "Type": "GPT: System"
+}`)
 	case "malicious":
 		fmt.Println(`
 [

--- a/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/single_disk_and_part
+++ b/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/single_disk_and_part
@@ -1,0 +1,39 @@
+product:
+    family: "1582.3"
+    name: Star 11 CPP
+    vendor: Micro-Star International Co., Ltd.
+cpu:
+    name: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
+    vendor: GenuineIntel
+    arch: amd64
+    cpus: 16
+    sockets: 1
+    cores: 8
+    threads: 2
+gpus:
+    - name: NVIDIA GeForce RTX 3050 Ti Laptop GPU
+      device: ""
+      vendor: NVIDIA
+      driver: nvldumdx.dll
+    - name: Intel(R) UHD Graphics
+      device: ""
+      vendor: Intel Corporation
+      driver: igdumdim0.dll
+mem:
+    total: 65237
+blks:
+    - size: 953867
+      type: disk
+      children:
+        - size: 100
+          type: 'GPT: System'
+          children: []
+screens:
+    - physicalresolution: 2560x1600
+      size: 300mm x 190mm
+      resolution: 1280x800
+      refreshrate: ""
+    - physicalresolution: 2560x1440
+      size: 600mm x 340mm
+      resolution: 2560x1440
+      refreshrate: ""


### PR DESCRIPTION
Fixes a collection failure on Windows that occurred when there was only a single disk, or a single partition. Also adds a new test to cover this case.

---
[UDENG-6605](https://warthogs.atlassian.net/browse/UDENG-6605)

[UDENG-6605]: https://warthogs.atlassian.net/browse/UDENG-6605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ