### PR TITLE
fix(systemd): Fix systemd containment permissions related to Wayland collection

### DIFF
--- a/.github/workflows/systemd-verify.yaml
+++ b/.github/workflows/systemd-verify.yaml
@@ -1,5 +1,8 @@
 name: Verify systemd files
 
+env:
+  apt_deps: "libwayland-dev"
+
 on:
   push:
     branches:
@@ -18,6 +21,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y ${{ env.apt_deps }}
       - name: Build Ubuntu-Insights
         run: |
           cd cmd/insights

--- a/autostart/systemd/ubuntu-insights-collect.service
+++ b/autostart/systemd/ubuntu-insights-collect.service
@@ -16,7 +16,6 @@ LockPersonality=yes
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=true
 PrivateTmp=yes
-PrivateIPC=yes
 PrivateUsers=yes
 ProtectControlGroups=yes
 ProtectKernelTunables=yes
@@ -27,11 +26,9 @@ SystemCallArchitectures=native
 SystemCallFilter=@system-service
 KeyringMode=private
 ProcSubset=pid
-ProtectHostname=yes
 IPAddressDeny=any
 ProtectProc=invisible
 RestrictAddressFamilies=AF_UNIX
-PrivateNetwork=yes
 RestrictNetworkInterfaces=yes
 
 [Install]

--- a/autostart/systemd/ubuntu-insights-collect.service
+++ b/autostart/systemd/ubuntu-insights-collect.service
@@ -30,7 +30,7 @@ ProcSubset=pid
 ProtectHostname=yes
 IPAddressDeny=any
 ProtectProc=invisible
-RestrictAddressFamilies=none
+RestrictAddressFamilies=AF_UNIX
 PrivateNetwork=yes
 RestrictNetworkInterfaces=yes
 

--- a/autostart/systemd/ubuntu-insights-upload.service
+++ b/autostart/systemd/ubuntu-insights-upload.service
@@ -16,7 +16,6 @@ MemoryDenyWriteExecute=yes
 NoNewPrivileges=true
 PrivateMounts=yes
 PrivateTmp=yes
-PrivateIPC=yes
 PrivateUsers=yes
 ProtectControlGroups=yes
 ProtectKernelTunables=yes
@@ -27,7 +26,6 @@ SystemCallArchitectures=native
 SystemCallFilter=@system-service
 KeyringMode=private
 ProcSubset=pid
-ProtectHostname=yes
 ProtectProc=invisible
 RestrictAddressFamilies=none
 


### PR DESCRIPTION
Fix systemd containment permissions that relate to Wayland screen info collection. 

The current settings are too restrictive and break display collection via Wayland if `ubuntu-insights` is triggered using systemd. This is due to `RestrictAddressFamilies=NONE` which should be set as `AF_UNIX`.

There also resolves an additional issue where certain settings don’t function properly, and are being ignored, resulting in warnings. While functionality is not affected, this could have issues in the future should those settings work, and there is an unexpected adverse effect on the functionality of `ubuntu-insights`.

---
[UDENG-6821](https://warthogs.atlassian.net/browse/UDENG-6821)

[UDENG-6821]: https://warthogs.atlassian.net/browse/UDENG-6821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ