### PR TITLE
fix: Ensure Built-Using is populated

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          libwayland-client0,
-Built-Using: ${misc:Built-Using}
+Built-Using: ${misc:Built-Using},
 Description: Ubuntu metrics reporting service
  Ubuntu Insights, a user transparent, open, 
  platform-agnostic and cross application solution for reporting

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ ifeq ($(strip $(shell ./debian/prepare-source.sh)),)
 	@echo "Vendoring probably failed"
 	exit 1
 endif
-	dh $@ --builddirectory=$(BUILDDIR) --buildsystem=golang
+	dh $@ --builddirectory=$(BUILDDIR) --buildsystem=golang --with=golang
 
 override_dh_auto_install:
 	mv $(BUILDDIR)/bin/insights $(BUILDDIR)/bin/ubuntu-insights


### PR DESCRIPTION
Using golang build package system is not enough, we need to ensure that golang debhelper is hooked in too to populate that field.
Fix a missing trailing comma too.
