### PR TITLE
fix: Hide completion command from help and man

### DIFF
--- a/cmd/ingest-service/daemon/daemon.go
+++ b/cmd/ingest-service/daemon/daemon.go
@@ -66,6 +66,7 @@ func New() (*App, error) {
 		},
 	}
 	a.viper = viper.New()
+	a.cmd.CompletionOptions.HiddenDefaultCmd = true
 
 	if err := installRootCmd(&a); err != nil {
 		return nil, err

--- a/cmd/insights/commands/root.go
+++ b/cmd/insights/commands/root.go
@@ -85,6 +85,7 @@ The information collected can't be used to identify a single machine. All report
 		},
 	}
 	a.viper = viper.New()
+	a.cmd.CompletionOptions.HiddenDefaultCmd = true
 
 	if err := installRootCmd(&a); err != nil {
 		return nil, err

--- a/cmd/web-service/daemon/daemon.go
+++ b/cmd/web-service/daemon/daemon.go
@@ -65,6 +65,7 @@ func New() (*App, error) {
 		},
 	}
 	a.viper = viper.New()
+	a.cmd.CompletionOptions.HiddenDefaultCmd = true
 
 	if err := installRootCmd(&a); err != nil {
 		return nil, err


### PR DESCRIPTION
Hide the completion command from help and man. The completion command will still exist, but will just be hidden.

Closes #105 

---
[UDENG-7061](https://warthogs.atlassian.net/browse/UDENG-7061)

[UDENG-7061]: https://warthogs.atlassian.net/browse/UDENG-7061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ