### PR TITLE
fix: Update README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Global Flags:
 ```json
 {
   "insightsVersion": "Dev",
+  "collectionTime": 1748013676,
   "systemInfo": {
     "hardware": {
       "product": {
@@ -218,14 +219,14 @@ Global Flags:
       ],
       "screens": [
         {
+          "physicalResolution": "2560x1440",
           "size": "600mm x 340mm",
-          "resolution": "2560x1440",
-          "refreshRate": "143.83"
+          "refreshRate": "143.85"
         },
         {
+          "physicalResolution": "2560x1600",
           "size": "300mm x 190mm",
-          "resolution": "1704x1065",
-          "refreshRate": "119.91"
+          "refreshRate": "120.00"
         }
       ]
     },
@@ -233,7 +234,7 @@ Global Flags:
       "os": {
         "family": "linux",
         "distribution": "Ubuntu",
-        "version": "24.04"
+        "version": "25.04"
       },
       "timezone": "EDT",
       "language": "en_US",

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Global Flags:
 ```json
 {
   "insightsVersion": "Dev",
+  "collectionTime": 1748012492,
   "systemInfo": {
     "hardware": {
       "cpu": {
@@ -300,18 +301,18 @@ Global Flags:
       "os": {
         "family": "linux",
         "distribution": "Ubuntu",
-        "version": "24.04"
+        "version": "25.04"
       },
       "timezone": "EDT",
-      "language": "C"
+      "language": "en_GB"
     },
     "platform": {
       "wsl": {
         "subsystemVersion": 2,
         "systemd": "used",
         "interop": "enabled",
-        "version": "2.4.11.0",
-        "kernelVersion": "5.15.167.4-microsoft-standard-WSL2"
+        "version": "2.5.7.0",
+        "kernelVersion": "6.6.87.1-microsoft-standard-WSL2"
       },
       "proAttached": true
     }


### PR DESCRIPTION
Update the README examples.

- Include `collectionTime`
- Bump versions
- Fix field names for Ubuntu Desktop `screens`

---
[UDENG-7039](https://warthogs.atlassian.net/browse/UDENG-7039)

[UDENG-7039]: https://warthogs.atlassian.net/browse/UDENG-7039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ