### PR TITLE
fix(debian): Update copyright and fix notice handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-ubuntu-insights (0.0.1~ppa7) questing; urgency=medium
+ubuntu-insights (0.0.1~ppa8) questing; urgency=medium
 
   * Initial release (LP: #2107478)
 
- -- Kat Kuo <kat.kuo@canonical.com>  Fri, 02 May 2025 11:29:47 -0400
+ -- Kat Kuo <kat.kuo@canonical.com>  Tue, 27 May 2025 17:44:48 -0400

--- a/debian/copyright
+++ b/debian/copyright
@@ -20,6 +20,10 @@ Files: vendor/github.com/davecgh/go-spew/*
 Copyright: 2012-2016, Dave Collins <dave@davec.name>
 License: ISC
 
+Files: vendor/github.com/docker/docker/*
+Copyright: 2012-2017 Docker, Inc.
+License: Apache-2.0
+
 Files: vendor/github.com/fsnotify/fsnotify/*
 Copyright: fsnotify Authors.
  2012, The Go Authors.
@@ -31,6 +35,10 @@ License: Expat
 
 Files: vendor/github.com/inconshreveable/mousetrap/*
 Copyright: 2022, Alan Shreve (@inconshreveable)
+License: Apache-2.0
+
+Files: vendor/github.com/moby/patternmatcher/*
+Copyright: 2012-2017 Docker, Inc.
 License: Apache-2.0
 
 Files: vendor/github.com/pelletier/go-toml/v2/*

--- a/debian/copyright
+++ b/debian/copyright
@@ -8,50 +8,412 @@ Copyright: 2025, Canonical Ltd
 License: GPL-3
 Comment: Debian packaging is licensed under the same terms as upstream
 
+Files: debian/*
+Copyright: 2025, Canonical Ltd
+License: GPL-3
+Comment: Debian packaging is licensed under the same terms as upstream
+
+Files: vendor/dario.cat/mergo/*
+Copyright: 2013, Dario Castañé.
+ 2012, The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/Azure/go-ansiterm/*
+Copyright: 2015, Microsoft Corporation
+License: Expat
+
 Files: vendor/github.com/BurntSushi/toml/*
 Copyright: 2013, TOML authors
 License: Expat
 
 Files: vendor/github.com/BurntSushi/toml/type_fields.go
-Copyright: 2010, The Go Authors.
+Copyright: 2009-2025, The Go Authors.
 License: BSD-3-clause
+
+Files: vendor/github.com/Microsoft/go-winio/*
+Copyright: 2015, Microsoft
+License: Expat
+
+Files: vendor/github.com/cenkalti/backoff/v4/*
+Copyright: 2014, Cenk AltÄ±
+License: Expat
+
+Files: vendor/github.com/containerd/log/*
+Copyright: The containerd Authors
+License: Apache-2.0
+
+Files: vendor/github.com/containerd/platforms/*
+Copyright: The containerd Authors
+License: Apache-2.0
+
+Files: vendor/github.com/cpuguy83/dockercfg/*
+Copyright: 2014, 2020, Brian Goff
+License: Expat
+
+Files: vendor/github.com/cpuguy83/go-md2man/v2/*
+Copyright: 2014, 2020, Brian Goff
+License: Expat
 
 Files: vendor/github.com/davecgh/go-spew/*
 Copyright: 2012-2016, Dave Collins <dave@davec.name>
 License: ISC
 
-Files: vendor/github.com/docker/docker/*
-Copyright: 2012-2017 Docker, Inc.
+Files: vendor/github.com/distribution/reference/*
+Copyright: no-info-found
 License: Apache-2.0
+
+Files: vendor/github.com/docker/docker/*
+Copyright: 2012-2018, Docker, Inc.
+License: Apache-2.0 or Expat
+
+Files: vendor/github.com/docker/docker/internal/lazyregexp/*
+Copyright: 2009-2025, The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/docker/go-connections/*
+Copyright: 2013-2018, Docker, Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/docker/go-units/*
+Copyright: 2013-2018, Docker, Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/ebitengine/purego/*
+Copyright: 2022-2024, The Ebitengine Authors
+License: Apache-2.0
+
+Files: vendor/github.com/ebitengine/purego/abi_amd64.h
+ vendor/github.com/ebitengine/purego/abi_arm64.h
+Copyright: 2009-2025, The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/ebitengine/purego/internal/fakecgo/abi_amd64.h
+ vendor/github.com/ebitengine/purego/internal/fakecgo/abi_arm64.h
+ vendor/github.com/ebitengine/purego/internal/fakecgo/asm_amd64.s
+ vendor/github.com/ebitengine/purego/internal/fakecgo/asm_arm64.s
+ vendor/github.com/ebitengine/purego/internal/fakecgo/callbacks.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/freebsd.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/go_darwin_amd64.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/go_darwin_arm64.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/go_freebsd_amd64.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/go_freebsd_arm64.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/go_linux_amd64.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/go_linux_arm64.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/iscgo.go
+ vendor/github.com/ebitengine/purego/internal/fakecgo/setenv.go
+Copyright: 2009-2025, The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/felixge/httpsnoop/*
+Copyright: 2016, Felix GeisendÃ¶rfer (felix@debuggable.com)
+License: Expat
 
 Files: vendor/github.com/fsnotify/fsnotify/*
 Copyright: fsnotify Authors.
  2012, The Go Authors.
 License: BSD-3-clause
 
+Files: vendor/github.com/go-logr/logr/*
+Copyright: 2019-2021, 2023, The logr Authors.
+License: Apache-2.0
+
+Files: vendor/github.com/go-logr/stdr/*
+Copyright: 2019, The logr Authors.
+License: Apache-2.0
+
+Files: vendor/github.com/go-ole/go-ole/*
+Copyright: 2013-2017, Yasuhiro Matsumoto, <mattn.jp@gmail.com>
+License: Expat
+
 Files: vendor/github.com/go-viper/mapstructure/v2/*
 Copyright: 2013, Mitchell Hashimoto
 License: Expat
+
+Files: vendor/github.com/go-viper/mapstructure/v2/internal/errors/join_go1_19.go
+Copyright: 2009-2025, The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/gogo/protobuf/*
+Copyright: 2013, The GoGo Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/gogo/protobuf/proto/*
+Copyright: 2009-2012, 2016-2018, The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/gogo/protobuf/proto/custom_gogo.go
+ vendor/github.com/gogo/protobuf/proto/duration_gogo.go
+ vendor/github.com/gogo/protobuf/proto/encode_gogo.go
+ vendor/github.com/gogo/protobuf/proto/extensions_gogo.go
+ vendor/github.com/gogo/protobuf/proto/lib_gogo.go
+ vendor/github.com/gogo/protobuf/proto/pointer_reflect_gogo.go
+ vendor/github.com/gogo/protobuf/proto/pointer_unsafe_gogo.go
+ vendor/github.com/gogo/protobuf/proto/properties_gogo.go
+ vendor/github.com/gogo/protobuf/proto/skip_gogo.go
+ vendor/github.com/gogo/protobuf/proto/table_marshal_gogo.go
+ vendor/github.com/gogo/protobuf/proto/table_unmarshal_gogo.go
+ vendor/github.com/gogo/protobuf/proto/text_gogo.go
+ vendor/github.com/gogo/protobuf/proto/timestamp_gogo.go
+ vendor/github.com/gogo/protobuf/proto/wrappers.go
+ vendor/github.com/gogo/protobuf/proto/wrappers_gogo.go
+Copyright: 2013, 2016, 2018, The GoGo Authors.
+License: BSD-2-clause
+
+Files: vendor/github.com/gogo/protobuf/proto/properties.go
+ vendor/github.com/gogo/protobuf/proto/text.go
+ vendor/github.com/gogo/protobuf/proto/text_parser.go
+Copyright: 2013, The GoGo Authors.
+ 2010, The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/golang-migrate/migrate/v4/*
+Copyright: 2018, Dale Hui
+ 2016, Matthias Kadenbach
+License: Expat
+
+Files: vendor/github.com/google/uuid/*
+Copyright: 2009, 2014, Google Inc.
+License: BSD-3-clause
+
+Files: vendor/github.com/hashicorp/errwrap/*
+Copyright: doctrines of fair use, fair dealing, or other equivalents.
+License: MPL-2.0
+
+Files: vendor/github.com/hashicorp/go-multierror/*
+Copyright: doctrines of fair use, fair dealing, or other equivalents.
+License: MPL-2.0
 
 Files: vendor/github.com/inconshreveable/mousetrap/*
 Copyright: 2022, Alan Shreve (@inconshreveable)
 License: Apache-2.0
 
+Files: vendor/github.com/jackc/chunkreader/v2/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/pgconn/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/pgerrcode/*
+Copyright: 2019, Jack Christensen
+License: Expat or PostgreSQL
+
+Files: vendor/github.com/jackc/pgio/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/pgpassfile/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/pgproto3/v2/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/pgservicefile/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/pgtype/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/pgx/v4/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/pgx/v4/go_stdlib.go
+Copyright: 2009-2012, 2016-2018, The Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/jackc/pgx/v5/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/jackc/puddle/v2/*
+Copyright: 2013-2021, Jack Christensen
+License: Expat
+
+Files: vendor/github.com/klauspost/compress/*
+Copyright: 2019, Klaus Post.
+ 2012, The Go Authors.
+License: Apache-2.0 or BSD-3-clause or Expat
+
+Files: vendor/github.com/klauspost/compress/fse/*
+Copyright: 2018, Klaus Post.
+ 2013, Yann Collet
+License: BSD-3-clause
+
+Files: vendor/github.com/klauspost/compress/huff0/bitreader.go
+ vendor/github.com/klauspost/compress/huff0/bitwriter.go
+Copyright: 2018, Klaus Post.
+ 2013, Yann Collet
+License: BSD-3-clause
+
+Files: vendor/github.com/klauspost/compress/internal/snapref/*
+Copyright: 2011, 2016, The Snappy-Go Authors.
+License: BSD-3-clause
+
+Files: vendor/github.com/klauspost/compress/zstd/*
+Copyright: 2019, Klaus Post.
+License: BSD-3-clause
+
+Files: vendor/github.com/klauspost/compress/zstd/bitreader.go
+ vendor/github.com/klauspost/compress/zstd/blockdec.go
+ vendor/github.com/klauspost/compress/zstd/blockenc.go
+ vendor/github.com/klauspost/compress/zstd/bytebuf.go
+ vendor/github.com/klauspost/compress/zstd/bytereader.go
+ vendor/github.com/klauspost/compress/zstd/decodeheader.go
+ vendor/github.com/klauspost/compress/zstd/decoder.go
+ vendor/github.com/klauspost/compress/zstd/decoder_options.go
+ vendor/github.com/klauspost/compress/zstd/enc_best.go
+ vendor/github.com/klauspost/compress/zstd/enc_better.go
+ vendor/github.com/klauspost/compress/zstd/enc_dfast.go
+ vendor/github.com/klauspost/compress/zstd/enc_fast.go
+ vendor/github.com/klauspost/compress/zstd/encoder.go
+ vendor/github.com/klauspost/compress/zstd/framedec.go
+ vendor/github.com/klauspost/compress/zstd/frameenc.go
+ vendor/github.com/klauspost/compress/zstd/fse_decoder.go
+ vendor/github.com/klauspost/compress/zstd/fse_encoder.go
+ vendor/github.com/klauspost/compress/zstd/fse_predefined.go
+ vendor/github.com/klauspost/compress/zstd/hash.go
+ vendor/github.com/klauspost/compress/zstd/history.go
+ vendor/github.com/klauspost/compress/zstd/matchlen_amd64.go
+ vendor/github.com/klauspost/compress/zstd/matchlen_generic.go
+ vendor/github.com/klauspost/compress/zstd/seqdec.go
+ vendor/github.com/klauspost/compress/zstd/seqenc.go
+ vendor/github.com/klauspost/compress/zstd/snappy.go
+ vendor/github.com/klauspost/compress/zstd/zip.go
+Copyright: 2019, 2020, Klaus Post.
+ 2013, Yann Collet
+License: BSD-3-clause
+
+Files: vendor/github.com/klauspost/compress/zstd/bitwriter.go
+Copyright: 2018, Klaus Post.
+ 2013, Yann Collet
+License: BSD-3-clause
+
+Files: vendor/github.com/klauspost/compress/zstd/internal/xxhash/*
+Copyright: 2016, Caleb Spare
+License: Expat
+
+Files: vendor/github.com/lib/pq/*
+Copyright: 2011, Blake Mizerany
+License: Expat
+
+Files: vendor/github.com/lib/pq/scram/*
+Copyright: 2014, Gustavo Niemeyer <gustavo@niemeyer.net>
+License: BSD-2-clause
+
+Files: vendor/github.com/lufia/plan9stats/*
+Copyright: 2019, KADOTA, Kyohei
+License: BSD-3-clause
+
+Files: vendor/github.com/magiconair/properties/*
+Copyright: 2013-2020, Frank Schroeder
+License: BSD-2-clause
+
+Files: vendor/github.com/magiconair/properties/decode.go
+ vendor/github.com/magiconair/properties/doc.go
+ vendor/github.com/magiconair/properties/integrate.go
+ vendor/github.com/magiconair/properties/lex.go
+ vendor/github.com/magiconair/properties/load.go
+ vendor/github.com/magiconair/properties/parser.go
+ vendor/github.com/magiconair/properties/properties.go
+ vendor/github.com/magiconair/properties/rangecheck.go
+Copyright: 2013-2022, Frank Schroeder.
+License: BSD-2-clause
+
+Files: vendor/github.com/moby/docker-image-spec/*
+Copyright: no-info-found
+License: Apache-2.0
+
 Files: vendor/github.com/moby/patternmatcher/*
-Copyright: 2012-2017 Docker, Inc.
+Copyright: 2012-2018, Docker, Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/moby/sys/sequential/*
+Copyright: no-info-found
+License: Apache-2.0
+
+Files: vendor/github.com/moby/sys/user/*
+Copyright: no-info-found
+License: Apache-2.0
+
+Files: vendor/github.com/moby/sys/userns/*
+Copyright: no-info-found
+License: Apache-2.0
+
+Files: vendor/github.com/moby/term/*
+Copyright: 2015, Docker, inc. Code released under the Apache 2.0 license. Docs released under Creative commons.
+ 2013-2018, Docker, Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/morikuni/aec/*
+Copyright: 2016, Taihei Morikuni
+License: Expat
+
+Files: vendor/github.com/opencontainers/go-digest/*
+Copyright: including, without limitation
+ 2019, 2020, OCI Contributors
+ 2016, 2017, Docker, Inc.
+License: Apache-2.0 or CC-BY-SA-4.0
+
+Files: vendor/github.com/opencontainers/go-digest/LICENSE
+ vendor/github.com/opencontainers/go-digest/algorithm.go
+ vendor/github.com/opencontainers/go-digest/digest.go
+ vendor/github.com/opencontainers/go-digest/digester.go
+ vendor/github.com/opencontainers/go-digest/doc.go
+ vendor/github.com/opencontainers/go-digest/verifiers.go
+Copyright: 2019, 2020, OCI Contributors
+ 2016, 2017, Docker, Inc.
+License: Apache-2.0
+
+Files: vendor/github.com/opencontainers/go-digest/LICENSE.docs
+Copyright: 2019, 2020, OCI Contributors
+ 2016, 2017, Docker, Inc.
+License: CC-BY-SA-4.0
+
+Files: vendor/github.com/opencontainers/image-spec/*
+Copyright: 2016, The Linux Foundation.
+License: Apache-2.0
+
+Files: vendor/github.com/opencontainers/image-spec/specs-go/*
+Copyright: 2016-2022, The Linux Foundation
 License: Apache-2.0
 
 Files: vendor/github.com/pelletier/go-toml/v2/*
 Copyright: 2021-2023, Thomas Pelletier
 License: Expat
 
+Files: vendor/github.com/pkg/errors/*
+Copyright: 2015, Dave Cheney <dave@cheney.net>
+License: BSD-2-clause
+
 Files: vendor/github.com/pmezard/go-difflib/*
 Copyright: 2013, Patrick Mezard
 License: BSD-3-clause
 
-Files: vendor/github.com/sagikazarmark/locafero/*
-Copyright: 2023, Márk Sági-Kazár <mark.sagikazar@gmail.com>
+Files: vendor/github.com/power-devops/perfstat/*
+Copyright: 2020, Power DevOps
 License: Expat
+
+Files: vendor/github.com/russross/blackfriday/v2/*
+Copyright: 2011, Russ Ross <russ@russross.com>
+License: BSD-2-clause
+
+Files: vendor/github.com/sagikazarmark/locafero/*
+Copyright: 2023, MÃ¡rk SÃ¡gi-KazÃ¡r <mark.sagikazar@gmail.com>
+License: Expat
+
+Files: vendor/github.com/shirou/gopsutil/v4/*
+Copyright: 2014, WAKAYAMA Shirou
+License: BSD-3-clause
+
+Files: vendor/github.com/shirou/gopsutil/v4/internal/common/binary.go
+Copyright: 2009-2012, 2016-2018, The Go Authors.
+License: BSD-3-clause
 
 Files: vendor/github.com/sirupsen/logrus/*
 Copyright: 2014, Simon Eskildsen
@@ -66,10 +428,49 @@ Copyright: 2023, Sourcegraph
 License: Expat
 
 Files: vendor/github.com/spf13/afero/*
-Copyright: 2014-2016 Steve Francia <spf@spf13.com>.
-           2015 The Hugo Authors
-           2016-present Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
-           2009-2015 The Go Authors.
+Copyright: 2016-2025, Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
+ 2015, The Hugo Authors
+ 2014-2016, Steve Francia <spf@spf13.com>.
+ 2009-2015, The Go Authors.
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/afero.go
+ vendor/github.com/spf13/afero/os.go
+Copyright: 2014, 2015, Steve Francia <spf@spf13.com>.
+ 2013, tsuru authors.
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/const_bsds.go
+ vendor/github.com/spf13/afero/const_win_unix.go
+ vendor/github.com/spf13/afero/httpFs.go
+ vendor/github.com/spf13/afero/lstater.go
+ vendor/github.com/spf13/afero/memmap.go
+ vendor/github.com/spf13/afero/symlink.go
+Copyright: 2014-2016, 2018, 2022, Steve Francia <spf@spf13.com>.
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/internal/*
+Copyright: 2014-2016, 2018, 2022, Steve Francia <spf@spf13.com>.
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/ioutil.go
+ vendor/github.com/spf13/afero/path.go
+Copyright: 2015, The Go Authors
+ 2015, Steve Francia <spf@spf13.com>
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/mem/*
+Copyright: 2014-2016, 2018, 2022, Steve Francia <spf@spf13.com>.
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/mem/file.go
+Copyright: 2014, 2015, Steve Francia <spf@spf13.com>.
+ 2013, tsuru authors.
+License: Apache-2.0
+
+Files: vendor/github.com/spf13/afero/util.go
+Copyright: 2015, The Hugo Authors
+ 2015, Steve Francia <spf@spf13.com>
 License: Apache-2.0
 
 Files: vendor/github.com/spf13/cast/*
@@ -87,7 +488,7 @@ License: BSD-3-clause
 
 Files: vendor/github.com/spf13/pflag/flag.go
  vendor/github.com/spf13/pflag/golangflag.go
-Copyright: 2009-2024, The Go Authors.
+Copyright: 2009-2025, The Go Authors.
 License: BSD-3-clause
 
 Files: vendor/github.com/spf13/viper/*
@@ -102,32 +503,64 @@ Files: vendor/github.com/subosito/gotenv/*
 Copyright: 2013, Alif Rachmawadi
 License: Expat
 
+Files: vendor/github.com/testcontainers/testcontainers-go/*
+Copyright: 2017-2019, Gianluca Arbezzano
+License: Expat
+
+Files: vendor/github.com/tklauser/go-sysconf/*
+Copyright: 2018-2022, Tobias Klauser
+License: BSD-3-clause
+
+Files: vendor/github.com/tklauser/numcpus/*
+Copyright: 2018-2022, Tobias Klauser
+License: Apache-2.0
+
 Files: vendor/github.com/ubuntu/decorate/*
 Copyright: 2022, 2023, Canonical Ltd.
 License: Expat
 
+Files: vendor/github.com/yusufpapurcu/wmi/*
+Copyright: 2013, Stack Exchange
+License: Expat
+
+Files: vendor/go.opentelemetry.io/auto/sdk/*
+Copyright: The OpenTelemetry Authors
+License: Apache-2.0
+
+Files: vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/*
+Copyright: The OpenTelemetry Authors
+License: Apache-2.0
+
+Files: vendor/go.opentelemetry.io/otel/*
+Copyright: The OpenTelemetry Authors
+License: Apache-2.0
+
 Files: vendor/go.uber.org/*
-Copyright: 2016-2021 Uber Technologies, Inc.
+Copyright: 2016-2021, Uber Technologies, Inc.
 License: Expat
 
 Files: vendor/*golang.org/*
-Copyright: 2009, The Go Authors.
+Copyright: 2009-2025, The Go Authors.
 License: BSD-3-clause
+
+Files: vendor/gopkg.in/ini.v1/*
+Copyright: 2014-2017, 2019, Unknwon
+License: Apache-2.0
 
 Files: vendor/gopkg.in/yaml.v3/*
 Copyright: 2011-2019 Canonical Ltd.
 License: Apache-2.0
 
 Files: vendor/gopkg.in/yaml.v3/apic.go
-       vendor/gopkg.in/yaml.v3/emitterc.go
-       vendor/gopkg.in/yaml.v3/parserc.go
-       vendor/gopkg.in/yaml.v3/readerc.go
-       vendor/gopkg.in/yaml.v3/scannerc.go
-       vendor/gopkg.in/yaml.v3/writerc.go
-       vendor/gopkg.in/yaml.v3/yamlh.go
-       vendor/gopkg.in/yaml.v3/yamlprivateh.go
-Copyright: 2011-2019 Canonical Ltd.
-           2006-2011 Kirill Simonov
+ vendor/gopkg.in/yaml.v3/emitterc.go
+ vendor/gopkg.in/yaml.v3/parserc.go
+ vendor/gopkg.in/yaml.v3/readerc.go
+ vendor/gopkg.in/yaml.v3/scannerc.go
+ vendor/gopkg.in/yaml.v3/writerc.go
+ vendor/gopkg.in/yaml.v3/yamlh.go
+ vendor/gopkg.in/yaml.v3/yamlprivateh.go
+Copyright: 2011-2019, Canonical Ltd
+ 2006-2010, Kirill Simonov
 License: Expat
 
 License: Apache-2.0
@@ -142,6 +575,30 @@ License: Apache-2.0
  limitations under the License.
  On Debian systems, the complete text of the Apache License,
  Version 2.0 can be found in '/usr/share/common-licenses/Apache-2.0'.
+
+License: BSD-2-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+     * Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+ copyright notice, this list of conditions and the following disclaimer
+ in the documentation and/or other materials provided with the
+ distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 License: BSD-3-clause
  The BSD License
@@ -172,6 +629,433 @@ License: BSD-3-clause
  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: CC-BY-SA-4.0
+ Attribution-ShareAlike 4.0 International
+ .
+ =======================================================================
+ .
+ Creative Commons Corporation ("Creative Commons") is not a law firm and
+ does not provide legal services or legal advice. Distribution of
+ Creative Commons public licenses does not create a lawyer-client or
+ other relationship. Creative Commons makes its licenses and related
+ information available on an "as-is" basis. Creative Commons gives no
+ warranties regarding its licenses, any material licensed under their
+ terms and conditions, or any related information. Creative Commons
+ disclaims all liability for damages resulting from their use to the
+ fullest extent possible.
+ .
+ Using Creative Commons Public Licenses
+ .
+ Creative Commons public licenses provide a standard set of terms and
+ conditions that creators and other rights holders may use to share
+ original works of authorship and other material subject to copyright
+ and certain other rights specified in the public license below. The
+ following considerations are for informational purposes only, are not
+ exhaustive, and do not form part of our licenses.
+ .
+      Considerations for licensors: Our public licenses are
+      intended for use by those authorized to give the public
+      permission to use material in ways otherwise restricted by
+      copyright and certain other rights. Our licenses are
+      irrevocable. Licensors should read and understand the terms
+      and conditions of the license they choose before applying it.
+      Licensors should also secure all rights necessary before
+      applying our licenses so that the public can reuse the
+      material as expected. Licensors should clearly mark any
+      material not subject to the license. This includes other CC-
+      licensed material, or material used under an exception or
+      limitation to copyright. More considerations for licensors:
+  wiki.creativecommons.org/Considerations_for_licensors
+ .
+      Considerations for the public: By using one of our public
+      licenses, a licensor grants the public permission to use the
+      licensed material under specified terms and conditions. If
+      the licensor's permission is not necessary for any reason--for
+      example, because of any applicable exception or limitation to
+      copyright--then that use is not regulated by the license. Our
+      licenses grant only permissions under copyright and certain
+      other rights that a licensor has authority to grant. Use of
+      the licensed material may still be restricted for other
+      reasons, including because others have copyright or other
+      rights in the material. A licensor may make special requests,
+      such as asking that all changes be marked or described.
+      Although not required by our licenses, you are encouraged to
+      respect those requests where reasonable. More_considerations
+      for the public:
+  wiki.creativecommons.org/Considerations_for_licensees
+ .
+ =======================================================================
+ .
+ Creative Commons Attribution-ShareAlike 4.0 International Public
+ License
+ .
+ By exercising the Licensed Rights (defined below), You accept and agree
+ to be bound by the terms and conditions of this Creative Commons
+ Attribution-ShareAlike 4.0 International Public License ("Public
+ License"). To the extent this Public License may be interpreted as a
+ contract, You are granted the Licensed Rights in consideration of Your
+ acceptance of these terms and conditions, and the Licensor grants You
+ such rights in consideration of benefits the Licensor receives from
+ making the Licensed Material available under these terms and
+ conditions.
+ .
+ .
+ Section 1 -- Definitions.
+ .
+   a. Adapted Material means material subject to Copyright and Similar
+      Rights that is derived from or based upon the Licensed Material
+      and in which the Licensed Material is translated, altered,
+      arranged, transformed, or otherwise modified in a manner requiring
+      permission under the Copyright and Similar Rights held by the
+      Licensor. For purposes of this Public License, where the Licensed
+      Material is a musical work, performance, or sound recording,
+      Adapted Material is always produced where the Licensed Material is
+      synched in timed relation with a moving image.
+ .
+   b. Adapter's License means the license You apply to Your Copyright
+      and Similar Rights in Your contributions to Adapted Material in
+      accordance with the terms and conditions of this Public License.
+ .
+   c. BY-SA Compatible License means a license listed at
+      creativecommons.org/compatiblelicenses, approved by Creative
+      Commons as essentially the equivalent of this Public License.
+ .
+   d. Copyright and Similar Rights means copyright and/or similar rights
+      closely related to copyright including, without limitation,
+      performance, broadcast, sound recording, and Sui Generis Database
+      Rights, without regard to how the rights are labeled or
+      categorized. For purposes of this Public License, the rights
+      specified in Section 2(b)(1)-(2) are not Copyright and Similar
+      Rights.
+ .
+   e. Effective Technological Measures means those measures that, in the
+      absence of proper authority, may not be circumvented under laws
+      fulfilling obligations under Article 11 of the WIPO Copyright
+      Treaty adopted on December 20, 1996, and/or similar international
+      agreements.
+ .
+   f. Exceptions and Limitations means fair use, fair dealing, and/or
+      any other exception or limitation to Copyright and Similar Rights
+      that applies to Your use of the Licensed Material.
+ .
+   g. License Elements means the license attributes listed in the name
+      of a Creative Commons Public License. The License Elements of this
+      Public License are Attribution and ShareAlike.
+ .
+   h. Licensed Material means the artistic or literary work, database,
+      or other material to which the Licensor applied this Public
+      License.
+ .
+   i. Licensed Rights means the rights granted to You subject to the
+      terms and conditions of this Public License, which are limited to
+      all Copyright and Similar Rights that apply to Your use of the
+      Licensed Material and that the Licensor has authority to license.
+ .
+   j. Licensor means the individual(s) or entity(ies) granting rights
+      under this Public License.
+ .
+   k. Share means to provide material to the public by any means or
+      process that requires permission under the Licensed Rights, such
+      as reproduction, public display, public performance, distribution,
+      dissemination, communication, or importation, and to make material
+      available to the public including in ways that members of the
+      public may access the material from a place and at a time
+      individually chosen by them.
+ .
+   l. Sui Generis Database Rights means rights other than copyright
+      resulting from Directive 96/9/EC of the European Parliament and of
+      the Council of 11 March 1996 on the legal protection of databases,
+      as amended and/or succeeded, as well as other essentially
+      equivalent rights anywhere in the world.
+ .
+   m. You means the individual or entity exercising the Licensed Rights
+      under this Public License. Your has a corresponding meaning.
+ .
+ .
+ Section 2 -- Scope.
+ .
+   a. License grant.
+ .
+        1. Subject to the terms and conditions of this Public License,
+           the Licensor hereby grants You a worldwide, royalty-free,
+           non-sublicensable, non-exclusive, irrevocable license to
+           exercise the Licensed Rights in the Licensed Material to:
+ .
+             a. reproduce and Share the Licensed Material, in whole or
+                in part; and
+ .
+             b. produce, reproduce, and Share Adapted Material.
+ .
+        2. Exceptions and Limitations. For the avoidance of doubt, where
+           Exceptions and Limitations apply to Your use, this Public
+           License does not apply, and You do not need to comply with
+           its terms and conditions.
+ .
+        3. Term. The term of this Public License is specified in Section
+           6(a).
+ .
+        4. Media and formats; technical modifications allowed. The
+           Licensor authorizes You to exercise the Licensed Rights in
+           all media and formats whether now known or hereafter created,
+           and to make technical modifications necessary to do so. The
+           Licensor waives and/or agrees not to assert any right or
+           authority to forbid You from making technical modifications
+           necessary to exercise the Licensed Rights, including
+           technical modifications necessary to circumvent Effective
+           Technological Measures. For purposes of this Public License,
+           simply making modifications authorized by this Section 2(a)
+           (4) never produces Adapted Material.
+ .
+        5. Downstream recipients.
+ .
+             a. Offer from the Licensor -- Licensed Material. Every
+                recipient of the Licensed Material automatically
+                receives an offer from the Licensor to exercise the
+                Licensed Rights under the terms and conditions of this
+                Public License.
+ .
+             b. Additional offer from the Licensor -- Adapted Material.
+                Every recipient of Adapted Material from You
+                automatically receives an offer from the Licensor to
+                exercise the Licensed Rights in the Adapted Material
+                under the conditions of the Adapter's License You apply.
+ .
+             c. No downstream restrictions. You may not offer or impose
+                any additional or different terms or conditions on, or
+                apply any Effective Technological Measures to, the
+                Licensed Material if doing so restricts exercise of the
+                Licensed Rights by any recipient of the Licensed
+                Material.
+ .
+        6. No endorsement. Nothing in this Public License constitutes or
+           may be construed as permission to assert or imply that You
+           are, or that Your use of the Licensed Material is, connected
+           with, or sponsored, endorsed, or granted official status by,
+           the Licensor or others designated to receive attribution as
+           provided in Section 3(a)(1)(A)(i).
+ .
+   b. Other rights.
+ .
+        1. Moral rights, such as the right of integrity, are not
+           licensed under this Public License, nor are publicity,
+           privacy, and/or other similar personality rights; however, to
+           the extent possible, the Licensor waives and/or agrees not to
+           assert any such rights held by the Licensor to the limited
+           extent necessary to allow You to exercise the Licensed
+           Rights, but not otherwise.
+ .
+        2. Patent and trademark rights are not licensed under this
+           Public License.
+ .
+        3. To the extent possible, the Licensor waives any right to
+           collect royalties from You for the exercise of the Licensed
+           Rights, whether directly or through a collecting society
+           under any voluntary or waivable statutory or compulsory
+           licensing scheme. In all other cases the Licensor expressly
+           reserves any right to collect such royalties.
+ .
+ .
+ Section 3 -- License Conditions.
+ .
+ Your exercise of the Licensed Rights is expressly made subject to the
+ following conditions.
+ .
+   a. Attribution.
+ .
+        1. If You Share the Licensed Material (including in modified
+           form), You must:
+ .
+             a. retain the following if it is supplied by the Licensor
+                with the Licensed Material:
+ .
+                  i. identification of the creator(s) of the Licensed
+                     Material and any others designated to receive
+                     attribution, in any reasonable manner requested by
+                     the Licensor (including by pseudonym if
+                     designated);
+ .
+                 ii. a copyright notice;
+ .
+                iii. a notice that refers to this Public License;
+ .
+                 iv. a notice that refers to the disclaimer of
+                     warranties;
+ .
+                  v. a URI or hyperlink to the Licensed Material to the
+                     extent reasonably practicable;
+ .
+             b. indicate if You modified the Licensed Material and
+                retain an indication of any previous modifications; and
+ .
+             c. indicate the Licensed Material is licensed under this
+                Public License, and include the text of, or the URI or
+                hyperlink to, this Public License.
+ .
+        2. You may satisfy the conditions in Section 3(a)(1) in any
+           reasonable manner based on the medium, means, and context in
+           which You Share the Licensed Material. For example, it may be
+           reasonable to satisfy the conditions by providing a URI or
+           hyperlink to a resource that includes the required
+           information.
+ .
+        3. If requested by the Licensor, You must remove any of the
+           information required by Section 3(a)(1)(A) to the extent
+           reasonably practicable.
+ .
+   b. ShareAlike.
+ .
+      In addition to the conditions in Section 3(a), if You Share
+      Adapted Material You produce, the following conditions also apply.
+ .
+        1. The Adapter's License You apply must be a Creative Commons
+           license with the same License Elements, this version or
+           later, or a BY-SA Compatible License.
+ .
+        2. You must include the text of, or the URI or hyperlink to, the
+           Adapter's License You apply. You may satisfy this condition
+           in any reasonable manner based on the medium, means, and
+           context in which You Share Adapted Material.
+ .
+        3. You may not offer or impose any additional or different terms
+           or conditions on, or apply any Effective Technological
+           Measures to, Adapted Material that restrict exercise of the
+           rights granted under the Adapter's License You apply.
+ .
+ .
+ Section 4 -- Sui Generis Database Rights.
+ .
+ Where the Licensed Rights include Sui Generis Database Rights that
+ apply to Your use of the Licensed Material:
+ .
+   a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+      to extract, reuse, reproduce, and Share all or a substantial
+      portion of the contents of the database;
+ .
+   b. if You include all or a substantial portion of the database
+      contents in a database in which You have Sui Generis Database
+      Rights, then the database in which You have Sui Generis Database
+      Rights (but not its individual contents) is Adapted Material,
+ .
+      including for purposes of Section 3(b); and
+   c. You must comply with the conditions in Section 3(a) if You Share
+      all or a substantial portion of the contents of the database.
+ .
+ For the avoidance of doubt, this Section 4 supplements and does not
+ replace Your obligations under this Public License where the Licensed
+ Rights include other Copyright and Similar Rights.
+ .
+ .
+ Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+ .
+   a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+      EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+      AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+      ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+      IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+      WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+      PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+      ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+      KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+      ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+ .
+   b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+      TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+      NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+      INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+      COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+      USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+      ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+      DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+      IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+ .
+   c. The disclaimer of warranties and limitation of liability provided
+      above shall be interpreted in a manner that, to the extent
+      possible, most closely approximates an absolute disclaimer and
+      waiver of all liability.
+ .
+ .
+ Section 6 -- Term and Termination.
+ .
+   a. This Public License applies for the term of the Copyright and
+      Similar Rights licensed here. However, if You fail to comply with
+      this Public License, then Your rights under this Public License
+      terminate automatically.
+ .
+   b. Where Your right to use the Licensed Material has terminated under
+      Section 6(a), it reinstates:
+ .
+        1. automatically as of the date the violation is cured, provided
+           it is cured within 30 days of Your discovery of the
+           violation; or
+ .
+        2. upon express reinstatement by the Licensor.
+ .
+      For the avoidance of doubt, this Section 6(b) does not affect any
+      right the Licensor may have to seek remedies for Your violations
+      of this Public License.
+ .
+   c. For the avoidance of doubt, the Licensor may also offer the
+      Licensed Material under separate terms or conditions or stop
+      distributing the Licensed Material at any time; however, doing so
+      will not terminate this Public License.
+ .
+   d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+      License.
+ .
+ .
+ Section 7 -- Other Terms and Conditions.
+ .
+   a. The Licensor shall not be bound by any additional or different
+      terms or conditions communicated by You unless expressly agreed.
+ .
+   b. Any arrangements, understandings, or agreements regarding the
+      Licensed Material not stated herein are separate from and
+      independent of the terms and conditions of this Public License.
+ .
+ .
+ Section 8 -- Interpretation.
+ .
+   a. For the avoidance of doubt, this Public License does not, and
+      shall not be interpreted to, reduce, limit, restrict, or impose
+      conditions on any use of the Licensed Material that could lawfully
+      be made without permission under this Public License.
+ .
+   b. To the extent possible, if any provision of this Public License is
+      deemed unenforceable, it shall be automatically reformed to the
+      minimum extent necessary to make it enforceable. If the provision
+      cannot be reformed, it shall be severed from this Public License
+      without affecting the enforceability of the remaining terms and
+      conditions.
+ .
+   c. No term or condition of this Public License will be waived and no
+      failure to comply consented to unless expressly agreed to by the
+      Licensor.
+ .
+   d. Nothing in this Public License constitutes or may be interpreted
+      as a limitation upon, or waiver of, any privileges and immunities
+      that apply to the Licensor or You, including from the legal
+      processes of any jurisdiction or authority.
+ .
+ .
+ =======================================================================
+ .
+ Creative Commons is not a party to its public licenses.
+ Notwithstanding, Creative Commons may elect to apply one of its public
+ licenses to material it publishes and in those instances will be
+ considered the "Licensor." Except for the limited purpose of indicating
+ that material is shared under a Creative Commons public license or as
+ otherwise permitted by the Creative Commons policies published at
+ creativecommons.org/policies, Creative Commons does not authorize the
+ use of the trademark "Creative Commons" or any other trademark or logo
+ of Creative Commons without its prior written consent including,
+ without limitation, in connection with any unauthorized modifications
+ to any of its public licenses or any other arrangements,
+ understandings, or agreements concerning use of licensed material. For
+ the avoidance of doubt, this paragraph does not form part of the public
+ licenses.
+ .
+ Creative Commons may be contacted at creativecommons.org.
 
 License: Expat
  The MIT License
@@ -224,3 +1108,399 @@ License: ISC
  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+License: MPL-2.0
+ Mozilla Public License Version 2.0
+ ==================================
+ .
+ 1. Definitions
+ --------------
+ .
+ 1.1. "Contributor"
+     means each individual or legal entity that creates, contributes to
+     the creation of, or owns Covered Software.
+ .
+ 1.2. "Contributor Version"
+     means the combination of the Contributions of others (if any) used
+     by a Contributor and that particular Contributor's Contribution.
+ .
+ 1.3. "Contribution"
+     means Covered Software of a particular Contributor.
+ .
+ 1.4. "Covered Software"
+     means Source Code Form to which the initial Contributor has attached
+     the notice in Exhibit A, the Executable Form of such Source Code
+     Form, and Modifications of such Source Code Form, in each case
+     including portions thereof.
+ .
+ 1.5. "Incompatible With Secondary Licenses"
+     means
+ .
+     (a) that the initial Contributor has attached the notice described
+         in Exhibit B to the Covered Software; or
+ .
+     (b) that the Covered Software was made available under the terms of
+         version 1.1 or earlier of the License, but not also under the
+         terms of a Secondary License.
+ .
+ 1.6. "Executable Form"
+     means any form of the work other than Source Code Form.
+ .
+ 1.7. "Larger Work"
+     means a work that combines Covered Software with other material, in
+     a separate file or files, that is not Covered Software.
+ .
+ 1.8. "License"
+     means this document.
+ .
+ 1.9. "Licensable"
+     means having the right to grant, to the maximum extent possible,
+     whether at the time of the initial grant or subsequently, any and
+     all of the rights conveyed by this License.
+ .
+ 1.10. "Modifications"
+     means any of the following:
+ .
+     (a) any file in Source Code Form that results from an addition to,
+         deletion from, or modification of the contents of Covered
+         Software; or
+ .
+     (b) any new file in Source Code Form that contains any Covered
+         Software.
+ .
+ 1.11. "Patent Claims" of a Contributor
+     means any patent claim(s), including without limitation, method,
+     process, and apparatus claims, in any patent Licensable by such
+     Contributor that would be infringed, but for the grant of the
+     License, by the making, using, selling, offering for sale, having
+     made, import, or transfer of either its Contributions or its
+     Contributor Version.
+ .
+ 1.12. "Secondary License"
+     means either the GNU General Public License, Version 2.0, the GNU
+     Lesser General Public License, Version 2.1, the GNU Affero General
+     Public License, Version 3.0, or any later versions of those
+     licenses.
+ .
+ 1.13. "Source Code Form"
+     means the form of the work preferred for making modifications.
+ .
+ 1.14. "You" (or "Your")
+     means an individual or a legal entity exercising rights under this
+     License. For legal entities, "You" includes any entity that
+     controls, is controlled by, or is under common control with You. For
+     purposes of this definition, "control" means (a) the power, direct
+     or indirect, to cause the direction or management of such entity,
+     whether by contract or otherwise, or (b) ownership of more than
+     fifty percent (50%) of the outstanding shares or beneficial
+     ownership of such entity.
+ .
+ 2. License Grants and Conditions
+ --------------------------------
+ .
+ 2.1. Grants
+ .
+ Each Contributor hereby grants You a world-wide, royalty-free,
+ non-exclusive license:
+ .
+ (a) under intellectual property rights (other than patent or trademark)
+     Licensable by such Contributor to use, reproduce, make available,
+     modify, display, perform, distribute, and otherwise exploit its
+     Contributions, either on an unmodified basis, with Modifications, or
+     as part of a Larger Work; and
+ .
+ (b) under Patent Claims of such Contributor to make, use, sell, offer
+     for sale, have made, import, and otherwise transfer either its
+     Contributions or its Contributor Version.
+ .
+ 2.2. Effective Date
+ .
+ The licenses granted in Section 2.1 with respect to any Contribution
+ become effective for each Contribution on the date the Contributor first
+ distributes such Contribution.
+ .
+ 2.3. Limitations on Grant Scope
+ .
+ The licenses granted in this Section 2 are the only rights granted under
+ this License. No additional rights or licenses will be implied from the
+ distribution or licensing of Covered Software under this License.
+ Notwithstanding Section 2.1(b) above, no patent license is granted by a
+ Contributor:
+ .
+ (a) for any code that a Contributor has removed from Covered Software;
+     or
+ .
+ (b) for infringements caused by: (i) Your and any other third party's
+     modifications of Covered Software, or (ii) the combination of its
+     Contributions with other software (except as part of its Contributor
+     Version); or
+ .
+ (c) under Patent Claims infringed by Covered Software in the absence of
+     its Contributions.
+ .
+ This License does not grant any rights in the trademarks, service marks,
+ or logos of any Contributor (except as may be necessary to comply with
+ the notice requirements in Section 3.4).
+ .
+ 2.4. Subsequent Licenses
+ .
+ No Contributor makes additional grants as a result of Your choice to
+ distribute the Covered Software under a subsequent version of this
+ License (see Section 10.2) or under the terms of a Secondary License (if
+ permitted under the terms of Section 3.3).
+ .
+ 2.5. Representation
+ .
+ Each Contributor represents that the Contributor believes its
+ Contributions are its original creation(s) or it has sufficient rights
+ to grant the rights to its Contributions conveyed by this License.
+ .
+ 2.6. Fair Use
+ .
+ This License is not intended to limit any rights You have under
+ applicable copyright doctrines of fair use, fair dealing, or other
+ equivalents.
+ .
+ 2.7. Conditions
+ .
+ Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+ in Section 2.1.
+ .
+ 3. Responsibilities
+ -------------------
+ .
+ 3.1. Distribution of Source Form
+ .
+ All distribution of Covered Software in Source Code Form, including any
+ Modifications that You create or to which You contribute, must be under
+ the terms of this License. You must inform recipients that the Source
+ Code Form of the Covered Software is governed by the terms of this
+ License, and how they can obtain a copy of this License. You may not
+ attempt to alter or restrict the recipients' rights in the Source Code
+ Form.
+ .
+ 3.2. Distribution of Executable Form
+ .
+ If You distribute Covered Software in Executable Form then:
+ .
+ (a) such Covered Software must also be made available in Source Code
+     Form, as described in Section 3.1, and You must inform recipients of
+     the Executable Form how they can obtain a copy of such Source Code
+     Form by reasonable means in a timely manner, at a charge no more
+     than the cost of distribution to the recipient; and
+ .
+ (b) You may distribute such Executable Form under the terms of this
+     License, or sublicense it under different terms, provided that the
+     license for the Executable Form does not attempt to limit or alter
+     the recipients' rights in the Source Code Form under this License.
+ .
+ 3.3. Distribution of a Larger Work
+ .
+ You may create and distribute a Larger Work under terms of Your choice,
+ provided that You also comply with the requirements of this License for
+ the Covered Software. If the Larger Work is a combination of Covered
+ Software with a work governed by one or more Secondary Licenses, and the
+ Covered Software is not Incompatible With Secondary Licenses, this
+ License permits You to additionally distribute such Covered Software
+ under the terms of such Secondary License(s), so that the recipient of
+ the Larger Work may, at their option, further distribute the Covered
+ Software under the terms of either this License or such Secondary
+ License(s).
+ .
+ 3.4. Notices
+ .
+ You may not remove or alter the substance of any license notices
+ (including copyright notices, patent notices, disclaimers of warranty,
+ or limitations of liability) contained within the Source Code Form of
+ the Covered Software, except that You may alter any license notices to
+ the extent required to remedy known factual inaccuracies.
+ .
+ 3.5. Application of Additional Terms
+ .
+ You may choose to offer, and to charge a fee for, warranty, support,
+ indemnity or liability obligations to one or more recipients of Covered
+ Software. However, You may do so only on Your own behalf, and not on
+ behalf of any Contributor. You must make it absolutely clear that any
+ such warranty, support, indemnity, or liability obligation is offered by
+ You alone, and You hereby agree to indemnify every Contributor for any
+ liability incurred by such Contributor as a result of warranty, support,
+ indemnity or liability terms You offer. You may include additional
+ disclaimers of warranty and limitations of liability specific to any
+ jurisdiction.
+ .
+ 4. Inability to Comply Due to Statute or Regulation
+ ---------------------------------------------------
+ .
+ If it is impossible for You to comply with any of the terms of this
+ License with respect to some or all of the Covered Software due to
+ statute, judicial order, or regulation then You must: (a) comply with
+ the terms of this License to the maximum extent possible; and (b)
+ describe the limitations and the code they affect. Such description must
+ be placed in a text file included with all distributions of the Covered
+ Software under this License. Except to the extent prohibited by statute
+ or regulation, such description must be sufficiently detailed for a
+ recipient of ordinary skill to be able to understand it.
+ .
+ 5. Termination
+ --------------
+ .
+ 5.1. The rights granted under this License will terminate automatically
+ if You fail to comply with any of its terms. However, if You become
+ compliant, then the rights granted under this License from a particular
+ Contributor are reinstated (a) provisionally, unless and until such
+ Contributor explicitly and finally terminates Your grants, and (b) on an
+ ongoing basis, if such Contributor fails to notify You of the
+ non-compliance by some reasonable means prior to 60 days after You have
+ come back into compliance. Moreover, Your grants from a particular
+ Contributor are reinstated on an ongoing basis if such Contributor
+ notifies You of the non-compliance by some reasonable means, this is the
+ first time You have received notice of non-compliance with this License
+ from such Contributor, and You become compliant prior to 30 days after
+ Your receipt of the notice.
+ .
+ 5.2. If You initiate litigation against any entity by asserting a patent
+ infringement claim (excluding declaratory judgment actions,
+ counter-claims, and cross-claims) alleging that a Contributor Version
+ directly or indirectly infringes any patent, then the rights granted to
+ You by any and all Contributors for the Covered Software under Section
+ 2.1 of this License shall terminate.
+ .
+ 5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+ end user license agreements (excluding distributors and resellers) which
+ have been validly granted by You or Your distributors under this License
+ prior to termination shall survive termination.
+ .
+ ************************************************************************
+ *                                                                      *
+ *  6. Disclaimer of Warranty                                           *
+ *  -------------------------                                           *
+ *                                                                      *
+ *  Covered Software is provided under this License on an "as is"       *
+ *  basis, without warranty of any kind, either expressed, implied, or  *
+ *  statutory, including, without limitation, warranties that the       *
+ *  Covered Software is free of defects, merchantable, fit for a        *
+ *  particular purpose or non-infringing. The entire risk as to the     *
+ *  quality and performance of the Covered Software is with You.        *
+ *  Should any Covered Software prove defective in any respect, You     *
+ *  (not any Contributor) assume the cost of any necessary servicing,   *
+ *  repair, or correction. This disclaimer of warranty constitutes an   *
+ *  essential part of this License. No use of any Covered Software is   *
+ *  authorized under this License except under this disclaimer.         *
+ *                                                                      *
+ ************************************************************************
+ .
+ ************************************************************************
+ *                                                                      *
+ *  7. Limitation of Liability                                          *
+ *  --------------------------                                          *
+ *                                                                      *
+ *  Under no circumstances and under no legal theory, whether tort      *
+ *  (including negligence), contract, or otherwise, shall any           *
+ *  Contributor, or anyone who distributes Covered Software as          *
+ *  permitted above, be liable to You for any direct, indirect,         *
+ *  special, incidental, or consequential damages of any character      *
+ *  including, without limitation, damages for lost profits, loss of    *
+ *  goodwill, work stoppage, computer failure or malfunction, or any    *
+ *  and all other commercial damages or losses, even if such party      *
+ *  shall have been informed of the possibility of such damages. This   *
+ *  limitation of liability shall not apply to liability for death or   *
+ *  personal injury resulting from such party's negligence to the       *
+ *  extent applicable law prohibits such limitation. Some               *
+ *  jurisdictions do not allow the exclusion or limitation of           *
+ *  incidental or consequential damages, so this exclusion and          *
+ *  limitation may not apply to You.                                    *
+ *                                                                      *
+ ************************************************************************
+ .
+ 8. Litigation
+ -------------
+ .
+ Any litigation relating to this License may be brought only in the
+ courts of a jurisdiction where the defendant maintains its principal
+ place of business and such litigation shall be governed by laws of that
+ jurisdiction, without reference to its conflict-of-law provisions.
+ Nothing in this Section shall prevent a party's ability to bring
+ cross-claims or counter-claims.
+ .
+ 9. Miscellaneous
+ ----------------
+ .
+ This License represents the complete agreement concerning the subject
+ matter hereof. If any provision of this License is held to be
+ unenforceable, such provision shall be reformed only to the extent
+ necessary to make it enforceable. Any law or regulation which provides
+ that the language of a contract shall be construed against the drafter
+ shall not be used to construe this License against a Contributor.
+ .
+ 10. Versions of the License
+ ---------------------------
+ .
+ 10.1. New Versions
+ .
+ Mozilla Foundation is the license steward. Except as provided in Section
+ 10.3, no one other than the license steward has the right to modify or
+ publish new versions of this License. Each version will be given a
+ distinguishing version number.
+ .
+ 10.2. Effect of New Versions
+ .
+ You may distribute the Covered Software under the terms of the version
+ of the License under which You originally received the Covered Software,
+ or under the terms of any subsequent version published by the license
+ steward.
+ .
+ 10.3. Modified Versions
+ .
+ If you create software not governed by this License, and you want to
+ create a new license for such software, you may create and use a
+ modified version of this License if you rename the license and remove
+ any references to the name of the license steward (except to note that
+ such modified license differs from this License).
+ .
+ 10.4. Distributing Source Code Form that is Incompatible With Secondary
+ Licenses
+ .
+ If You choose to distribute Source Code Form that is Incompatible With
+ Secondary Licenses under the terms of this version of the License, the
+ notice described in Exhibit B of this License must be attached.
+ .
+ Exhibit A - Source Code Form License Notice
+ -------------------------------------------
+ .
+   This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ .
+ If it is not possible or desirable to put the notice in a particular
+ file, then You may include the notice in a location (such as a LICENSE
+ file in a relevant directory) where a recipient would be likely to look
+ for such a notice.
+ .
+ You may add additional accurate notices of copyright ownership.
+ .
+ Exhibit B - "Incompatible With Secondary Licenses" Notice
+ ---------------------------------------------------------
+ .
+   This Source Code Form is "Incompatible With Secondary Licenses", as
+   defined by the Mozilla Public License, v. 2.0.
+
+License: PostgreSQL
+ The PostgreSQL License
+ .
+ Copyright (c) 2025, the copyright holder
+ .
+ Permission to use, copy, modify, and distribute this software and its
+ documentation for any purpose, without fee, and without a written agreement is
+ hereby granted, provided that the above copyright notice and this paragraph
+ and the following two paragraphs appear in all copies.
+ .
+ IN NO EVENT SHALL the copyright holder BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
+ OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ the copyright holder HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ .
+ the copyright holder SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+ AND the copyright holder HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE, SUPPORT,
+ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/debian/install
+++ b/debian/install
@@ -2,3 +2,5 @@ autostart/systemd/* usr/lib/systemd/user
 usr/share/bash-completion
 usr/share/man
 usr/share/zsh
+vendor/github.com/moby/patternmatcher/NOTICE usr/share/doc/ubuntu-insights/moby-patternmatcher
+vendor/github.com/docker/docker/NOTICE usr/share/doc/ubuntu-insights/docker

--- a/debian/lrc.config
+++ b/debian/lrc.config
@@ -1,0 +1,11 @@
+_build
+debian/ubuntu-insights
+
+# False positive
+vendor/gopkg.in/yaml.v3/LICENSE
+vendor/github.com/klauspost/compress/LICENSE
+vendor/github.com/docker/docker/LICENSE
+vendor/github.com/docker/docker/NOTICE
+
+# BSD-style license based on CRYPTOGAMS BSD-3 code
+vendor/golang.org/x/crypto/chacha20/chacha_ppc64x.s


### PR DESCRIPTION
Update the `debian/copyright` file, include Apache 2.0 notices in deb package docs.

---
[UDENG-7001](https://warthogs.atlassian.net/browse/UDENG-7001)

[UDENG-7001]: https://warthogs.atlassian.net/browse/UDENG-7001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ