### PR TITLE
fix(debian/control): Fix vcs links

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,8 @@ Build-Depends: debhelper-compat (= 13),
                dctrl-tools,
                libwayland-dev,
 Standards-Version: 4.6.2
-Vcs-Browser: https://salsa.debian.org/go-team/packages/ubuntu-insights
-Vcs-Git: https://salsa.debian.org/go-team/packages/ubuntu-insights.git
+Vcs-Browser: https://github.com/ubuntu/ubuntu-insights
+Vcs-Git: https://github.com/ubuntu/ubuntu-insights.git
 Homepage: https://github.com/ubuntu/ubuntu-insights
 XS-Go-Import-Path: github.com/ubuntu/ubuntu-insights
 


### PR DESCRIPTION
Fixed the vcs links in `debian/control`.