### PR TITLE
ci: Add workflow to run lrc

### DIFF
--- a/.github/workflows/lrc-qa.yaml
+++ b/.github/workflows/lrc-qa.yaml
@@ -1,0 +1,32 @@
+name: Validate debian/copyright
+
+env:
+  apt_deps: "licenserecon"
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+    paths:
+      - "debian/copyright"
+      - "go.mod"
+
+jobs:
+  run-lrc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y ${{ env.apt_deps }}
+      - name: Vendor Go modules
+        run: |
+          go mod vendor
+      - name: Run lrc
+        run: |
+          lrc


### PR DESCRIPTION
Adds a workflow to run `lrc` to check the validity of `debian/copyright`.
- Only runs when `debian/copyright` or `go.mod` are modified.

---
[UDENG-7156](https://warthogs.atlassian.net/browse/UDENG-7156)

[UDENG-7156]: https://warthogs.atlassian.net/browse/UDENG-7156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ