### PR TITLE
docs(debian/README.source): Add README.source

### DIFF
--- a/debian/README.source
+++ b/debian/README.source
@@ -1,0 +1,14 @@
+# Getting the Source
+The source for this package can be found here https://github.com/ubuntu/ubuntu-insights
+
+Note that while this package only includes the client command line tool and supporting systemd service triggers, the source also includes the source for server side services.
+
+# Refreshing vendored code
+
+This package uses vendored go code tracked in `go.sum`. While it is automatically refreshed during the build process, the code can be refreshed manually using the following:
+
+```shell
+go mod vendor
+```
+
+Note that some of the vendored code is not used for the client command line tool binaries included with this package, and may be only relevant for the server services also in the source.


### PR DESCRIPTION
Add README.source file to meet the requirements needed for MIR. https://canonical-ubuntu-project.readthedocs-hosted.com/MIR/mir-reporters-template/#mir-reporters-template

Some of this might end up not being needed, but it is a little easier to include it now instead of down the road.

---
[UDENG-7110](https://warthogs.atlassian.net/browse/UDENG-7110)

[UDENG-7110]: https://warthogs.atlassian.net/browse/UDENG-7110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ