### PR TITLE
fix: Disable lrc workflow

### DIFF
--- a/.github/workflows/lrc-qa.yaml
+++ b/.github/workflows/lrc-qa.yaml
@@ -3,16 +3,18 @@ name: Validate debian/copyright
 env:
   apt_deps: "licenserecon"
 
-on:
-  push:
-    branches:
-      - main
-    tags:
-      - "*"
-  pull_request:
-    paths:
-      - "debian/copyright"
-      - "go.mod"
+# on:
+#   push:
+#     branches:
+#       - main
+#     tags:
+#       - "*"
+#   pull_request:
+#     paths:
+#       - "debian/copyright"
+#       - "debian/lrc.config"
+#       - "go.mod"
+on: [workflow_dispatch]
 
 jobs:
   run-lrc:


### PR DESCRIPTION
Unfortunately, the `lrc` version in Universe for Noble has false positives and doesn't support `lrc.config`. At a minimum, we need `licenserecon` version 1.19, and only Plucky and Questing has versions greater than 1.19. GitHub runners only have the LTS releases of Ubuntu.