### PR TITLE
deps: Bump Go version to 1.24.4 in go.mod files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/ubuntu-insights
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/ubuntu-insights/tools
 
-go 1.24.2
+go 1.24.4
 
 require github.com/golangci/golangci-lint v1.64.8
 


### PR DESCRIPTION
Bump Go version to `1.24.4` in `go.mod` files

This should fix some of the go QA tests involving vulnerabilities. (I'm also going to look into moving away from the crypto package and instead using hash/crc32 to try and void CVE issues involving `crypto` since we don't really use it for cryptography reasons.)
