### PR TITLE
deps(go.mod): Set go toolchain version to 1.24.4, downgrade go to 1.24.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ubuntu/ubuntu-insights
 
-go 1.24.4
+go 1.24.0
+
+toolchain go1.24.4
 
 require (
 	github.com/BurntSushi/toml v1.5.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,8 @@
 module github.com/ubuntu/ubuntu-insights/tools
 
-go 1.24.4
+go 1.24.0
+
+toolchain go1.24.4
 
 require github.com/golangci/golangci-lint v1.64.8
 


### PR DESCRIPTION
Set the go toolchain version to 1.24.4, downgrade go to 1.24.0 in go.mod.

This is to deal with the current version of go in main being 1.24.2, allowing for the deb package to be built again. Since we use features from 1.24, the minimum version is still pegged to 1.24, but the toolchain version should generally still be the most recent patch.

Note that toolchain is set to local in `debian/rules` so it will use what is available locally.

---
[UDENG-7191](https://warthogs.atlassian.net/browse/UDENG-7191)

[UDENG-7191]: https://warthogs.atlassian.net/browse/UDENG-7191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ