### PR TITLE
feat: Filter out reserved names present in the allow list.

### DIFF
--- a/internal/server/shared/config/export_test.go
+++ b/internal/server/shared/config/export_test.go
@@ -8,3 +8,9 @@ func WithLogger(l *slog.Logger) Options {
 		o.Logger = l
 	}
 }
+
+// GetReservedNames returns a map of reserved names that the configuration
+// manager will filter from the allow list.
+func GetReservedNames() map[string]struct{} {
+	return reservedNames
+}


### PR DESCRIPTION
Filter out reserved names present in the allow list for server service dynamic config.
- Disallow any app names present in the dynamic config which may be problematic, primarily those that are equal to the names of non-standard app tables
- Disallow 'ubuntu_report' and 'schema_migrations' as app names
- Add relevant tests

---
[UDENG-7176](https://warthogs.atlassian.net/browse/UDENG-7176)

[UDENG-7176]: https://warthogs.atlassian.net/browse/UDENG-7176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ