### PR TITLE
build: Initial Deb Package Release 0.1.0

### DIFF
--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -1,5 +1,5 @@
-ubuntu-insights (0.0.1~ppa8) questing; urgency=medium
+ubuntu-insights (0.1.0) questing; urgency=medium
 
   * Initial release (LP: #2107478)
 
- -- Kat Kuo <kat.kuo@canonical.com>  Tue, 27 May 2025 17:44:48 -0400
+ -- Kat Kuo <kat.kuo@canonical.com>  Mon, 30 Jun 2025 09:50:12 -0400


### PR DESCRIPTION
Changes the version number in `debian/changelog` to `0.1.0` for the initial deb package release.

Before merging, the date should be updated. An associated version tag should also be made for the merge commit on main after merging. Additionally, after merging, this commit should be uploaded to launchpad. 