### PR TITLE
feat: Add report IDs to tables

### DIFF
--- a/internal/server/ingest/database/database_test.go
+++ b/internal/server/ingest/database/database_test.go
@@ -57,13 +57,14 @@ func TestUpload(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
+		id         string
 		data       *models.TargetModel
 		earlyClose bool
 		execErr    error
 
 		wantErr bool
 	}{
-		"successful exec": {},
+		"successful exec": {id: uuid.NewString()},
 		"opt-out successful exec": {
 			data: &models.TargetModel{
 				OptOut: true,
@@ -101,7 +102,7 @@ func TestUpload(t *testing.T) {
 				tc.data = &models.TargetModel{}
 			}
 
-			err = mgr.Upload(t.Context(), "test", tc.data)
+			err = mgr.Upload(t.Context(), tc.id, "test", tc.data)
 			if tc.wantErr {
 				require.Error(t, err, "Upload() error")
 				return
@@ -115,13 +116,14 @@ func TestUploadLegacy(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
+		id         string
 		report     *models.LegacyTargetModel
 		earlyClose bool
 		execErr    error
 
 		wantErr bool
 	}{
-		"successful exec": {},
+		"successful exec": {id: uuid.NewString()},
 		"opt-out successful exec": {
 			report: &models.LegacyTargetModel{
 				OptOut: true,
@@ -158,7 +160,7 @@ func TestUploadLegacy(t *testing.T) {
 				tc.report = &models.LegacyTargetModel{}
 			}
 
-			err = mgr.UploadLegacy(t.Context(), "test-distribution", "test-version", tc.report)
+			err = mgr.UploadLegacy(t.Context(), tc.id, "test-distribution", "test-version", tc.report)
 			if tc.wantErr {
 				require.Error(t, err, "Expected error on UploadLegacy() but got none")
 				return

--- a/internal/server/ingest/processor/processor_test.go
+++ b/internal/server/ingest/processor/processor_test.go
@@ -175,7 +175,7 @@ type mockDBManager struct {
 	invalidReports map[string][]string                    // Fake in-memory invalid reports
 }
 
-func (m *mockDBManager) Upload(ctx context.Context, app string, report *models.TargetModel) error {
+func (m *mockDBManager) Upload(ctx context.Context, id, app string, report *models.TargetModel) error {
 	if m.uploadErr != nil {
 		return m.uploadErr
 	}
@@ -184,18 +184,26 @@ func (m *mockDBManager) Upload(ctx context.Context, app string, report *models.T
 		m.reports = make(map[string][]*models.TargetModel)
 	}
 
+	if err := uuid.Validate(id); err != nil {
+		return errors.New("invalid UUID provided")
+	}
+
 	// Simulate storing the data in the fake database
 	m.reports[app] = append(m.reports[app], report)
 	return nil
 }
 
-func (m *mockDBManager) UploadLegacy(ctx context.Context, distribution, version string, report *models.LegacyTargetModel) error {
+func (m *mockDBManager) UploadLegacy(ctx context.Context, id, distribution, version string, report *models.LegacyTargetModel) error {
 	if m.uploadErr != nil {
 		return m.uploadErr
 	}
 
 	if m.legacyReports == nil {
 		m.legacyReports = make(map[string][]*models.LegacyTargetModel)
+	}
+
+	if err := uuid.Validate(id); err != nil {
+		return errors.New("invalid UUID provided")
 	}
 
 	// Simulate storing the legacy report in the fake database

--- a/migrations/000001_initialize-invalid_reports.down.sql
+++ b/migrations/000001_initialize-invalid_reports.down.sql
@@ -1,1 +1,5 @@
+DROP INDEX IF EXISTS idx_invalid_reports_report_id;
+DROP INDEX IF EXISTS idx_invalid_reports_entry_time;
+DROP INDEX IF EXISTS idx_invalid_reports_app_name;
+
 DROP TABLE IF EXISTS invalid_reports;

--- a/migrations/000001_initialize-invalid_reports.up.sql
+++ b/migrations/000001_initialize-invalid_reports.up.sql
@@ -5,3 +5,7 @@ CREATE TABLE invalid_reports (
     app_name TEXT NOT NULL,
     raw_report TEXT NOT NULL
 );
+
+CREATE INDEX idx_invalid_reports_report_id ON invalid_reports(report_id);
+CREATE INDEX idx_invalid_reports_entry_time ON invalid_reports(entry_time);
+CREATE INDEX idx_invalid_reports_app_name ON invalid_reports(app_name);

--- a/migrations/000002_initialize-linux.down.sql
+++ b/migrations/000002_initialize-linux.down.sql
@@ -1,7 +1,10 @@
-DROP INDEX IF EXISTS idx_linux_hardware;
-DROP INDEX IF EXISTS idx_linux_software;
-DROP INDEX IF EXISTS idx_linux_platform;
+DROP INDEX IF EXISTS idx_linux_optout;
 DROP INDEX IF EXISTS idx_linux_source_metrics;
+DROP INDEX IF EXISTS idx_linux_platform;
+DROP INDEX IF EXISTS idx_linux_software;
+DROP INDEX IF EXISTS idx_linux_hardware;
+DROP INDEX IF EXISTS idx_linux_collection_time;
+DROP INDEX IF EXISTS idx_linux_entry_time;
 DROP INDEX IF EXISTS idx_linux_report_id;
 
 DROP TABLE IF EXISTS linux;

--- a/migrations/000002_initialize-linux.down.sql
+++ b/migrations/000002_initialize-linux.down.sql
@@ -2,5 +2,6 @@ DROP INDEX IF EXISTS idx_linux_hardware;
 DROP INDEX IF EXISTS idx_linux_software;
 DROP INDEX IF EXISTS idx_linux_platform;
 DROP INDEX IF EXISTS idx_linux_source_metrics;
+DROP INDEX IF EXISTS idx_linux_report_id;
 
 DROP TABLE IF EXISTS linux;

--- a/migrations/000002_initialize-linux.up.sql
+++ b/migrations/000002_initialize-linux.up.sql
@@ -12,7 +12,10 @@ CREATE TABLE linux (
 );
 
 CREATE INDEX idx_linux_report_id ON linux(report_id);
+CREATE INDEX idx_linux_entry_time ON linux(entry_time);
+CREATE INDEX idx_linux_collection_time ON linux(collection_time);
 CREATE INDEX idx_linux_hardware ON linux USING gin (hardware);
 CREATE INDEX idx_linux_software ON linux USING gin (software);
 CREATE INDEX idx_linux_platform ON linux USING gin (platform);
 CREATE INDEX idx_linux_source_metrics ON linux USING gin (source_metrics);
+CREATE INDEX idx_linux_optout ON linux(optout);

--- a/migrations/000002_initialize-linux.up.sql
+++ b/migrations/000002_initialize-linux.up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE linux (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     insights_version TEXT,
     collection_time TIMESTAMP,
@@ -10,6 +11,7 @@ CREATE TABLE linux (
     optout BOOLEAN NOT NULL
 );
 
+CREATE INDEX idx_linux_report_id ON linux(report_id);
 CREATE INDEX idx_linux_hardware ON linux USING gin (hardware);
 CREATE INDEX idx_linux_software ON linux USING gin (software);
 CREATE INDEX idx_linux_platform ON linux USING gin (platform);

--- a/migrations/000003_initialize-windows.down.sql
+++ b/migrations/000003_initialize-windows.down.sql
@@ -2,5 +2,6 @@ DROP INDEX IF EXISTS idx_windows_hardware;
 DROP INDEX IF EXISTS idx_windows_software;
 DROP INDEX IF EXISTS idx_windows_platform;
 DROP INDEX IF EXISTS idx_windows_source_metrics;
+DROP INDEX IF EXISTS idx_windows_report_id;
 
 DROP TABLE IF EXISTS windows;

--- a/migrations/000003_initialize-windows.down.sql
+++ b/migrations/000003_initialize-windows.down.sql
@@ -1,7 +1,10 @@
-DROP INDEX IF EXISTS idx_windows_hardware;
-DROP INDEX IF EXISTS idx_windows_software;
-DROP INDEX IF EXISTS idx_windows_platform;
+DROP INDEX IF EXISTS idx_windows_optout;
 DROP INDEX IF EXISTS idx_windows_source_metrics;
+DROP INDEX IF EXISTS idx_windows_platform;
+DROP INDEX IF EXISTS idx_windows_software;
+DROP INDEX IF EXISTS idx_windows_hardware;
+DROP INDEX IF EXISTS idx_windows_collection_time;
+DROP INDEX IF EXISTS idx_windows_entry_time;
 DROP INDEX IF EXISTS idx_windows_report_id;
 
 DROP TABLE IF EXISTS windows;

--- a/migrations/000003_initialize-windows.up.sql
+++ b/migrations/000003_initialize-windows.up.sql
@@ -12,7 +12,10 @@ CREATE TABLE windows (
 );
 
 CREATE INDEX idx_windows_report_id ON windows(report_id);
+CREATE INDEX idx_windows_entry_time ON windows(entry_time);
+CREATE INDEX idx_windows_collection_time ON windows(collection_time);
 CREATE INDEX idx_windows_hardware ON windows USING gin (hardware);
 CREATE INDEX idx_windows_software ON windows USING gin (software);
 CREATE INDEX idx_windows_platform ON windows USING gin (platform);
 CREATE INDEX idx_windows_source_metrics ON windows USING gin (source_metrics);
+CREATE INDEX idx_windows_optout ON windows(optout);

--- a/migrations/000003_initialize-windows.up.sql
+++ b/migrations/000003_initialize-windows.up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE windows (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     insights_version TEXT,
     collection_time TIMESTAMP,
@@ -10,6 +11,7 @@ CREATE TABLE windows (
     optout BOOLEAN NOT NULL
 );
 
+CREATE INDEX idx_windows_report_id ON windows(report_id);
 CREATE INDEX idx_windows_hardware ON windows USING gin (hardware);
 CREATE INDEX idx_windows_software ON windows USING gin (software);
 CREATE INDEX idx_windows_platform ON windows USING gin (platform);

--- a/migrations/000004_initialize-darwin.down.sql
+++ b/migrations/000004_initialize-darwin.down.sql
@@ -2,5 +2,6 @@ DROP INDEX IF EXISTS idx_darwin_hardware;
 DROP INDEX IF EXISTS idx_darwin_software;
 DROP INDEX IF EXISTS idx_darwin_platform;
 DROP INDEX IF EXISTS idx_darwin_source_metrics;
+DROP INDEX IF EXISTS idx_darwin_report_id;
 
 DROP TABLE IF EXISTS darwin;

--- a/migrations/000004_initialize-darwin.down.sql
+++ b/migrations/000004_initialize-darwin.down.sql
@@ -1,7 +1,10 @@
-DROP INDEX IF EXISTS idx_darwin_hardware;
-DROP INDEX IF EXISTS idx_darwin_software;
-DROP INDEX IF EXISTS idx_darwin_platform;
+DROP INDEX IF EXISTS idx_darwin_optout;
 DROP INDEX IF EXISTS idx_darwin_source_metrics;
+DROP INDEX IF EXISTS idx_darwin_platform;
+DROP INDEX IF EXISTS idx_darwin_software;
+DROP INDEX IF EXISTS idx_darwin_hardware;
+DROP INDEX IF EXISTS idx_darwin_collection_time;
+DROP INDEX IF EXISTS idx_darwin_entry_time;
 DROP INDEX IF EXISTS idx_darwin_report_id;
 
 DROP TABLE IF EXISTS darwin;

--- a/migrations/000004_initialize-darwin.up.sql
+++ b/migrations/000004_initialize-darwin.up.sql
@@ -12,7 +12,10 @@ CREATE TABLE darwin (
 );
 
 CREATE INDEX idx_darwin_report_id ON darwin(report_id);
+CREATE INDEX idx_darwin_entry_time ON darwin(entry_time);
+CREATE INDEX idx_darwin_collection_time ON darwin(collection_time);
 CREATE INDEX idx_darwin_hardware ON darwin USING gin (hardware);
 CREATE INDEX idx_darwin_software ON darwin USING gin (software);
 CREATE INDEX idx_darwin_platform ON darwin USING gin (platform);
 CREATE INDEX idx_darwin_source_metrics ON darwin USING gin (source_metrics);
+CREATE INDEX idx_darwin_optout ON darwin(optout);

--- a/migrations/000004_initialize-darwin.up.sql
+++ b/migrations/000004_initialize-darwin.up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE darwin (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     insights_version TEXT,
     collection_time TIMESTAMP,
@@ -10,6 +11,7 @@ CREATE TABLE darwin (
     optout BOOLEAN NOT NULL
 );
 
+CREATE INDEX idx_darwin_report_id ON darwin(report_id);
 CREATE INDEX idx_darwin_hardware ON darwin USING gin (hardware);
 CREATE INDEX idx_darwin_software ON darwin USING gin (software);
 CREATE INDEX idx_darwin_platform ON darwin USING gin (platform);

--- a/migrations/000005_initialize-ubuntu_report.down.sql
+++ b/migrations/000005_initialize-ubuntu_report.down.sql
@@ -1,4 +1,8 @@
+DROP INDEX IF EXISTS idx_ubuntu_report_optout;
+
 DROP INDEX IF EXISTS idx_ubuntu_report_report;
+
+DROP INDEX IF EXISTS idx_ubuntu_report_entry_time;
 
 DROP INDEX IF EXISTS idx_ubuntu_report_report_id;
 

--- a/migrations/000005_initialize-ubuntu_report.down.sql
+++ b/migrations/000005_initialize-ubuntu_report.down.sql
@@ -1,3 +1,5 @@
 DROP INDEX IF EXISTS idx_ubuntu_report_report;
 
+DROP INDEX IF EXISTS idx_ubuntu_report_report_id;
+
 DROP TABLE IF EXISTS ubuntu_report;

--- a/migrations/000005_initialize-ubuntu_report.up.sql
+++ b/migrations/000005_initialize-ubuntu_report.up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE ubuntu_report (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     distribution TEXT NOT NULL,
     version TEXT NOT NULL,
@@ -8,3 +9,4 @@ CREATE TABLE ubuntu_report (
 );
 
 CREATE INDEX idx_ubuntu_report_report ON ubuntu_report USING gin (report);
+CREATE INDEX idx_ubuntu_report_report_id ON ubuntu_report(report_id);

--- a/migrations/000005_initialize-ubuntu_report.up.sql
+++ b/migrations/000005_initialize-ubuntu_report.up.sql
@@ -8,5 +8,7 @@ CREATE TABLE ubuntu_report (
     optout BOOLEAN NOT NULL
 );
 
+CREATE INDEX idx_ubuntu_report_entry_time ON ubuntu_report(entry_time);
+CREATE INDEX idx_ubuntu_report_optout ON ubuntu_report(optout);
 CREATE INDEX idx_ubuntu_report_report ON ubuntu_report USING gin (report);
 CREATE INDEX idx_ubuntu_report_report_id ON ubuntu_report(report_id);


### PR DESCRIPTION
Add report ID all apps tables, including the `ubuntu_report` table. This report ID is the same one used for the invalid reports table, parsed from the file name and re-generated as a UUID if the file name could not be parsed as a UUID. This field is indexed, but does not act as a key in case the UUID generation or the parsed UUID is not a true UUID for whatever reason.

This PR also adds a few missing indexes that would likely be used in queries. This increases costs of insertion, but performance is not critical. 