### PR TITLE
tests: Increase the timeout duration in waitWorkersEqual to 8 seconds

### DIFF
--- a/internal/server/ingest/ingest_test.go
+++ b/internal/server/ingest/ingest_test.go
@@ -244,7 +244,7 @@ func gracefulShutdown(t *testing.T, s *ingest.Service, runErr chan error) {
 func waitWorkersEqual(t *testing.T, s *ingest.Service, workers ...string) {
 	t.Helper()
 	delay := 500 * time.Millisecond
-	timeout := 5 * time.Second
+	timeout := 8 * time.Second
 
 	start := time.Now()
 	for {


### PR DESCRIPTION
Increase the timeout duration in `waitWorkersEqual` to 8 seconds. This will hopefully help with flaky tests on the macOS runners, which tend to be much slower than the other runners, resulting in these sorts of timing failures.