### PR TITLE
refactor: collector tweaks

### DIFF
--- a/cmd/insights/commands/root.go
+++ b/cmd/insights/commands/root.go
@@ -14,7 +14,7 @@ import (
 )
 
 type newUploader func(l *slog.Logger, cm uploader.Consent, cachePath string, minAge uint, dryRun bool, args ...uploader.Options) (uploader.Uploader, error)
-type newCollector func(l *slog.Logger, cm collector.Consent, cachePath, source string, period uint, dryRun bool, args ...collector.Options) (collector.Collector, error)
+type newCollector func(l *slog.Logger, cm collector.Consent, c collector.Config, args ...collector.Options) (collector.Collector, error)
 
 // App represents the application.
 type App struct {
@@ -27,7 +27,13 @@ type App struct {
 		insightsDir string
 
 		Upload  uploader.Config
-		Collect collector.Config
+		Collect struct {
+			Source            string
+			SourceMetricsPath string
+			Period            uint
+			Force             bool
+			DryRun            bool
+		}
 
 		Consent struct {
 			Sources []string

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_bad-file-consent_source
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_bad-file-consent_source
@@ -1,3 +1,4 @@
 source: Bad-File
 period: 1
+force: false
 dryrun: false

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_bad-file_consent_global_source
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_bad-file_consent_global_source
@@ -1,3 +1,0 @@
-source: Bad-File
-period: 1
-dryrun: false

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_basic
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_basic
@@ -1,3 +1,4 @@
-source: platform
+source: ""
 period: 1
+force: false
 dryrun: false

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_dry_run,_verbose_1
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_dry_run,_verbose_1
@@ -1,3 +1,4 @@
-source: platform
+source: ""
 period: 1
+force: false
 dryrun: true

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_dry_run,_verbose_2
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_dry_run,_verbose_2
@@ -1,3 +1,4 @@
-source: platform
+source: ""
 period: 1
+force: false
 dryrun: true

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_false-consent_source
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_false-consent_source
@@ -1,3 +1,4 @@
 source: "False"
 period: 1
+force: false
 dryrun: false

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_period_overflow
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_period_overflow
@@ -1,3 +1,0 @@
-source: platform
-period: 9223372036854775808
-dryrun: false

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_source_invalid_json
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_source_invalid_json
@@ -1,3 +1,0 @@
-source: source
-period: 1
-dryrun: false

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal
@@ -1,3 +1,4 @@
 source: source
 period: 1
+force: false
 dryrun: false

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal,_dry-run
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal,_dry-run
@@ -1,3 +1,4 @@
 source: source
 period: 1
+force: false
 dryrun: true

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal,_period
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal,_period
@@ -1,3 +1,4 @@
 source: source
 period: 10
+force: false
 dryrun: false

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal,_period,_dry-run
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal,_period,_dry-run
@@ -1,3 +1,4 @@
 source: source
 period: 10
+force: false
 dryrun: true

--- a/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal,_period,_dry-run,_force
+++ b/cmd/insights/commands/testdata/TestCollect/golden/collect_source_normal,_period,_dry-run,_force
@@ -1,3 +1,4 @@
 source: source
 period: 10
+force: true
 dryrun: true

--- a/cmd/insights/commands/testdata/TestCollect/golden/exit_0_when_no_consent_files
+++ b/cmd/insights/commands/testdata/TestCollect/golden/exit_0_when_no_consent_files
@@ -1,3 +1,4 @@
 source: Unknown
 period: 1
+force: false
 dryrun: false

--- a/internal/collector/testutils/collector.go
+++ b/internal/collector/testutils/collector.go
@@ -23,7 +23,6 @@ type timeProvider interface {
 
 //go:linkname defaultOptions github.com/ubuntu/ubuntu-insights/internal/collector.defaultOptions
 var defaultOptions struct {
-	sourceMetricsPath string
 	maxReports        uint
 	timeProvider      timeProvider
 	sysInfo           func(*slog.Logger, ...sysinfo.Options) collector.SysInfo


### PR DESCRIPTION
A refactor of collector creation in order for easier usage and improved testability. 

- Refactored the `New` function in the `collector` package to return an interface instead of a concrete struct for improved mocking. This improves testability, allowing of greater separation of concerns and the mocking of collector calls at the CLI and API level.
- Refactored the `New` function in the `collector` package to accept the  `collector.Config` struct. This helps deal with some of the readability issues in the collector creation process, and better emphasis which fields can be left as 'default values' without breaking things.
- Enhanced error handling in the `Sanitize` method of `collector.Config` to ensure proper validation of configuration values. Sanitize is now called by `New` itself, so the user doesn't need to remember to call it themselves.
- Updated tests to reflect changes in the collector configuration and added new tests for error scenarios.
- Removed source metrics set check in Sanitize as it is a CLI restriction, not a restriction of internal logic itself

There are also a few minor functionality changes. `New`/`Sanitize` now accept an empty string as cachePath, and will just convert it to the default value instead of erroring. This especially helps with the API usage for cases where we do want to use the default value, but the caller doesn't have access to this value since it is considered and internal constant.

This PR also serves as a final check for the collector component before the first tagged release of the client. I don't expect there to be any changes for the collector following this other than a change to allow for 0 value period usage (before the release), and the ability for the API to accept JSON inputs instead of paths to a JSON file (can be done after the tagged release).

---
[UDENG-7219](https://warthogs.atlassian.net/browse/UDENG-7219)

[UDENG-7219]: https://warthogs.atlassian.net/browse/UDENG-7219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ