### PR TITLE
docs: Create README for individual components

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,134 +17,14 @@ This is the code repository for **Ubuntu Insights**, a transparent, user-friendl
 
 Ubuntu Insights is designed to show you exactly what is being sent, and allow you to acknowledge and control your own data. The code in this repository is designed to mainly be invoked by a controlling application, but a command-line tool is also provided.
 
-This is designed to be a full replacement for Ubuntu Report.
+Ubuntu Insights is designed to be a full replacement for [Ubuntu Report](https://github.com/ubuntu/ubuntu-report) and its server components are backwards compatible.
 
-## About
+## Components
 
-Ubuntu Insights caches all collected data locally, and will only attempt to upload insights reports following a minimum period (1 week by default). It checks for consent both at the time of collection and at the time of upload. If consent was not given at either of those two points, then the information is not sent to the server. Once a report has been uploaded, it is removed from the `local` cache folder, and the data that was sent is written to the `uploaded` folder.
+Ubuntu Insights is divided into two components.
 
-By default, Ubuntu Insights will only collect once per collection period.
-
-To execute the interactive command-line interface manually, use `ubuntu-insights`.
-
-## Default Paths
-
-### Linux
-
-Consent Files: `~/.config/ubuntu-insights`
-
-Reports Cache: `~/.cache/ubuntu-insights`
-
-## Command-Line Interface Usage
-
-### ubuntu-insights
-
-`ubuntu-insights [command]`
-
-#### Options
-
-```
-Available Commands:
-  collect     Collect system information
-  completion  Generate the autocompletion script for the specified shell
-  consent     Manage or get user consent state
-  help        Help about any command
-  upload      Upload metrics to the Ubuntu Insights server
-
-Flags:
-      --config string         use a specific configuration file
-      --consent-dir string    the base directory of the consent state files
-  -h, --help                  help for ubuntu-insights
-      --insights-dir string   the base directory of the insights report cache
-  -v, --verbose count         issue INFO (-v), DEBUG (-vv)
-      --version               version for ubuntu-insights
-```
-
-### ubuntu-insights consent
-
-Manage or get user consent state for data collection and upload
-
-`ubuntu-insights consent [sources](optional arguments) [flags]`
-
-#### Options
-
-```
-Flags:
-  -h, --help           help for consent
-  -s, --state string   the consent state to set (true or false)
-
-Global Flags:
-      --config string        use a specific configuration file
-      --consent-dir string   the base directory of the consent state files
-  -v, --verbose count        issue INFO (-v), DEBUG (-vv)
-```
-
-#### Examples
-
-To get the global consent state using the default consent directory:
-
-```console
-foo@bar:~$ ubuntu-insights consent
-Global: false
-```
-
-To set the consent state for the source `linux`:
-
-```console
-foo@bar:~$ ubuntu-insights consent linux -s true
-linux: true
-```
-
-### ubuntu-insights collect
-
-Collect system information and metrics and store it locally.
-
-If source is not provided, then the source is assumed to be the currently detected platform. Additionally, there should be no source-metrics-path provided.
-If source is provided, then the source-metrics-path should be provided as well.
-
-`ubuntu-insights collect [source] [source-metrics-path](required if source provided) [flags]`
-
-#### Options
-
-```
-Flags:
-  -d, --dry-run       perform a dry-run where a report is collected, but not written to disk
-  -f, --force         force a collection, override the report if there are any conflicts (consent is still respected)
-  -h, --help          help for collect
-  -p, --period uint   the minimum period between 2 collection periods for validation purposes in seconds (default 1)
-
-Global Flags:
-      --config string         use a specific configuration file
-      --consent-dir string    the base directory of the consent state files
-      --insights-dir string   the base directory of the insights report cache
-  -v, --verbose count         issue INFO (-v), DEBUG (-vv)
-```
-
-### ubuntu-insights upload
-
-Upload metrics to the Ubuntu Insights server.
-
-If no sources are provided, all detected sources at the configured reports directory will be uploaded.
-If consent is not given for a source, an opt-out notification will be sent regardless of the locally cached insights report's contents.
-
-`ubuntu-insights upload [sources](optional arguments) [flags]`
-
-#### Options
-
-```
-Flags:
-  -d, --dry-run        go through the motions of doing an upload, but do not communicate with the server, send the payload, or modify local files
-  -f, --force          force an upload, ignoring min age and clashes between the collected file and a file in the uploaded folder, replacing the clashing uploaded report if it exists (doesn't ignore consent)
-  -h, --help           help for upload
-      --min-age uint   the minimum age (in seconds) of a report before the uploader will attempt to upload it (default 604800)
-  -r, --retry          enable a limited number of retries for failed uploads
-
-Global Flags:
-      --config string         use a specific configuration file
-      --consent-dir string    the base directory of the consent state files
-      --insights-dir string   the base directory of the insights report cache
-  -v, --verbose count         issue INFO (-v), DEBUG (-vv)
-```
+- The client for local actions which consists of a command-line interface, as well as Go and C APIs. It is also packaged as a deb package. See [insights](insights)
+- The server services which is what we use to aggregate reports. See [server-services](server-services)
 
 ## Example Insights Reports
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Ubuntu Insights is designed to be a full replacement for [Ubuntu Report](https:/
 
 ## Components
 
-Ubuntu Insights is divided into two components.
+Ubuntu Insights is divided into two components:
 
 - The client for local actions which consists of a command-line interface, as well as Go and C APIs. It is also packaged as a deb package. See [insights](insights)
-- The server services which is what we use to aggregate reports. See [server-services](server-services)
+- The server services which is what we use to aggregate reports. See [server](server)
 
 ## Example Insights Reports
 

--- a/insights/README.md
+++ b/insights/README.md
@@ -1,0 +1,146 @@
+# Ubuntu Insights Client
+
+The Ubuntu Insights Client is the component responsible for handling all local Ubuntu Insights actions. This component includes a command-line interface, a Go and C API, as well as the source for the `ubuntu-insights` deb package. 
+
+## About
+
+Ubuntu Insights caches all collected data locally, and will only attempt to upload insights reports following a minimum period (1 week by default). It checks for consent both at the time of collection and at the time of upload. If consent was not given at either of those two points, then the information is not sent to the server. Once a report has been uploaded, it is removed from the `local` cache folder, and the data that was sent is written to the `uploaded` folder.
+
+By default, Ubuntu Insights will only collect once per collection period.
+
+To execute the interactive command-line interface manually, use `ubuntu-insights`.
+
+### Example Insights Reports
+
+See [here](/#example-insights-reports)
+
+## Default Paths
+
+### Linux
+
+Consent Files: `~/.config/ubuntu-insights`
+
+Reports Cache: `~/.cache/ubuntu-insights`
+
+## Command-Line Interface Usage
+
+### ubuntu-insights
+
+`ubuntu-insights [command]`
+
+#### Options
+
+```
+Available Commands:
+  collect     Collect system information
+  completion  Generate the autocompletion script for the specified shell
+  consent     Manage or get user consent state
+  help        Help about any command
+  upload      Upload metrics to the Ubuntu Insights server
+
+Flags:
+      --config string         use a specific configuration file
+      --consent-dir string    the base directory of the consent state files
+  -h, --help                  help for ubuntu-insights
+      --insights-dir string   the base directory of the insights report cache
+  -v, --verbose count         issue INFO (-v), DEBUG (-vv)
+      --version               version for ubuntu-insights
+```
+
+### ubuntu-insights consent
+
+Manage or get user consent state for data collection and upload
+
+`ubuntu-insights consent [sources](optional arguments) [flags]`
+
+#### Options
+
+```
+Flags:
+  -h, --help           help for consent
+  -s, --state string   the consent state to set (true or false)
+
+Global Flags:
+      --config string        use a specific configuration file
+      --consent-dir string   the base directory of the consent state files
+  -v, --verbose count        issue INFO (-v), DEBUG (-vv)
+```
+
+#### Examples
+
+To get the global consent state using the default consent directory:
+
+```console
+foo@bar:~$ ubuntu-insights consent
+Global: false
+```
+
+To set the consent state for the source `linux`:
+
+```console
+foo@bar:~$ ubuntu-insights consent linux -s true
+linux: true
+```
+
+### ubuntu-insights collect
+
+Collect system information and metrics and store it locally.
+
+If source is not provided, then the source is assumed to be the currently detected platform. Additionally, there should be no source-metrics-path provided.
+If source is provided, then the source-metrics-path should be provided as well.
+
+`ubuntu-insights collect [source] [source-metrics-path](required if source provided) [flags]`
+
+#### Options
+
+```
+Flags:
+  -d, --dry-run       perform a dry-run where a report is collected, but not written to disk
+  -f, --force         force a collection, override the report if there are any conflicts (consent is still respected)
+  -h, --help          help for collect
+  -p, --period uint   the minimum period between 2 collection periods for validation purposes in seconds (default 1)
+
+Global Flags:
+      --config string         use a specific configuration file
+      --consent-dir string    the base directory of the consent state files
+      --insights-dir string   the base directory of the insights report cache
+  -v, --verbose count         issue INFO (-v), DEBUG (-vv)
+```
+
+### ubuntu-insights upload
+
+Upload metrics to the Ubuntu Insights server.
+
+If no sources are provided, all detected sources at the configured reports directory will be uploaded.
+If consent is not given for a source, an opt-out notification will be sent regardless of the locally cached insights report's contents.
+
+`ubuntu-insights upload [sources](optional arguments) [flags]`
+
+#### Options
+
+```
+Flags:
+  -d, --dry-run        go through the motions of doing an upload, but do not communicate with the server, send the payload, or modify local files
+  -f, --force          force an upload, ignoring min age and clashes between the collected file and a file in the uploaded folder, replacing the clashing uploaded report if it exists (doesn't ignore consent)
+  -h, --help           help for upload
+      --min-age uint   the minimum age (in seconds) of a report before the uploader will attempt to upload it (default 604800)
+  -r, --retry          enable a limited number of retries for failed uploads
+
+Global Flags:
+      --config string         use a specific configuration file
+      --consent-dir string    the base directory of the consent state files
+      --insights-dir string   the base directory of the insights report cache
+  -v, --verbose count         issue INFO (-v), DEBUG (-vv)
+```
+
+### Hidden commands
+
+These commands are hidden from help, and should primarily be used by the system or for debugging.
+
+#### ubuntu-insights completion
+
+Generate the autocompletion script for ubuntu-insights for the specified shell.
+
+`
+  ubuntu-insights completion [shell]
+`

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,7 @@
+# Ubuntu Insights Server Services
+
+The Ubuntu Insights Services are the components for aggregating and processing reports. They do not record any personally identifying information such as IPs.
+
+There are two server services, a web exposed web service which handles incoming HTTP requests as well as an ingest service which does simple validations before inserting reports into a database.
+
+Neither of these services are meant for local use.


### PR DESCRIPTION
This PR creates individual README files for the individual components following the reorganization of the project repository. It moves the `ubuntu-insights` client usage documentation into a dedicated README within the `insights` module, and adds a bare-bones README file for the server services. All links used are relative.

Note that the collection examples are still in the root README file, but the `insights` README does link to it.

The server services README will be fleshed out further in another PR once the CLI and charm stabilizes.

---
[UDENG-7255](https://warthogs.atlassian.net/browse/UDENG-7255)

[UDENG-7255]: https://warthogs.atlassian.net/browse/UDENG-7255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ