### PR TITLE
feat: Implement JSON source metrics for APIs

### DIFF
--- a/insights/C/insights_types.h
+++ b/insights/C/insights_types.h
@@ -1,0 +1,45 @@
+#ifndef INSIGHTS_TYPES_H
+#define INSIGHTS_TYPES_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef enum {
+  CONSENT_UNKNOWN = -1,
+  CONSENT_FALSE = 0,
+  CONSENT_TRUE = 1,
+} ConsentState;
+
+typedef struct {
+  const char *source;      // default: runtime.GOOS
+  const char *consentDir;  // default: "${os.UserConfigDir}/ubuntu-insights"
+  const char *insightsDir; // default: "${os.UserCacheDir}/ubuntu-insights"
+  bool verbose;            // default: false
+} InsightsConfig;
+
+/**
+ * @brief Parameters for insights collection.
+ *
+ * @note sourceMetricsPath and sourceMetricsJSON are mutually exclusive.
+ */
+typedef struct {
+  const char *sourceMetricsPath; // Path to JSON file (default: empty)
+  const void *sourceMetricsJSON; // Raw JSON data as bytes (default: NULL)
+  size_t sourceMetricsJSONLen;   // Length of sourceMetricsJSON in bytes
+  unsigned int period;           // Collection period in seconds (default: 0)
+  bool force;  // Force collection, ignoring duplicates (default: false)
+  bool dryRun; // Simulate operation without writing files (default: false)
+} CollectFlags;
+
+typedef struct {
+  unsigned int minAge; // default: 1
+  bool force, dryRun;  // default: false
+} UploadFlags;
+
+// typedefs to be able to have `const` in Go.
+typedef const char Cchar;
+typedef const InsightsConfig CInsightsConfig;
+typedef const CollectFlags CCollectFlags;
+typedef const UploadFlags CUploadFlags;
+
+#endif // INSIGHTS_TYPES_H

--- a/insights/C/testdata/TestCollect/golden/all_get_converted
+++ b/insights/C/testdata/TestCollect/golden/all_get_converted
@@ -3,8 +3,9 @@ conf:
     consentdir: home/etc/wsl/dir
     insightsdir: insights/wsl/dir
     verbose: false
-metrics: metrics
 flags:
+    sourcemetricspath: metrics
+    sourcemetricsjson: []
     period: 2000
     force: false
     dryrun: false

--- a/insights/C/testdata/TestCollect/golden/config_gets_converted
+++ b/insights/C/testdata/TestCollect/golden/config_gets_converted
@@ -3,8 +3,9 @@ conf:
     consentdir: home/etc/dir
     insightsdir: insights/dir
     verbose: true
-metrics: ""
 flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
     period: 0
     force: false
     dryrun: false

--- a/insights/C/testdata/TestCollect/golden/empty_values_are_empty
+++ b/insights/C/testdata/TestCollect/golden/empty_values_are_empty
@@ -3,8 +3,9 @@ conf:
     consentdir: ""
     insightsdir: ""
     verbose: false
-metrics: ""
 flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
     period: 0
     force: false
     dryrun: false

--- a/insights/C/testdata/TestCollect/golden/error_returns_error_string
+++ b/insights/C/testdata/TestCollect/golden/error_returns_error_string
@@ -3,8 +3,9 @@ conf:
     consentdir: ""
     insightsdir: ""
     verbose: false
-metrics: ""
 flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
     period: 0
     force: false
     dryrun: false

--- a/insights/C/testdata/TestCollect/golden/flags_get_converted
+++ b/insights/C/testdata/TestCollect/golden/flags_get_converted
@@ -3,8 +3,9 @@ conf:
     consentdir: ""
     insightsdir: ""
     verbose: false
-metrics: ""
 flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
     period: 10
     force: true
     dryrun: true

--- a/insights/C/testdata/TestCollect/golden/metricspath_gets_converted
+++ b/insights/C/testdata/TestCollect/golden/metricspath_gets_converted
@@ -3,8 +3,9 @@ conf:
     consentdir: ""
     insightsdir: ""
     verbose: false
-metrics: path/to/metrics
 flags:
+    sourcemetricspath: path/to/metrics
+    sourcemetricsjson: []
     period: 0
     force: false
     dryrun: false

--- a/insights/C/testdata/TestCollect/golden/null_values_are_empty
+++ b/insights/C/testdata/TestCollect/golden/null_values_are_empty
@@ -3,8 +3,9 @@ conf:
     consentdir: ""
     insightsdir: ""
     verbose: false
-metrics: ""
 flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
     period: 0
     force: false
     dryrun: false

--- a/insights/C/testdata/TestCollect/golden/sourcemetricsjson_gets_converted
+++ b/insights/C/testdata/TestCollect/golden/sourcemetricsjson_gets_converted
@@ -1,0 +1,27 @@
+conf:
+    source: ""
+    consentdir: ""
+    insightsdir: ""
+    verbose: false
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson:
+        - 123
+        - 34
+        - 107
+        - 101
+        - 121
+        - 34
+        - 58
+        - 32
+        - 34
+        - 118
+        - 97
+        - 108
+        - 117
+        - 101
+        - 34
+        - 125
+    period: 0
+    force: false
+    dryrun: false

--- a/insights/api.go
+++ b/insights/api.go
@@ -36,9 +36,11 @@ type Config struct {
 
 // CollectFlags represents optional parameters for Collect.
 type CollectFlags struct {
-	Period uint
-	Force  bool
-	DryRun bool
+	SourceMetricsPath string // Path to a JSON file a valid JSON object for source metrics.
+	SourceMetricsJSON []byte // JSON object for source metrics.
+	Period            uint
+	Force             bool
+	DryRun            bool
 }
 
 // UploadFlags represents optional parameters for Upload.
@@ -48,18 +50,23 @@ type UploadFlags struct {
 	DryRun bool
 }
 
-// Collect creates a report for Config.Source.
-// metricsPath is a filepath to a JSON file containing extra metrics.
-// If Config.Source is "",  the source is the platform and metricsPath is ignored.
+// Collect creates a report for Config.Source and writes it to Config.InsightsDir.
+//
+// The SourceMetricsPath and SouceMetricsJSON fields in flags are mutually exclusive.
+// If both are set, an error will be returned.
+// If SourceMetricsPath in flags is set, it must be a valid path to a JSON file with a valid JSON object.
+// SourceMetricsJSON in flags if set must be a valid JSON object, not an array or primitive.
+//
 // returns an error if collection fails.
-func (c Config) Collect(metricsPath string, flags CollectFlags) error {
+func (c Config) Collect(flags CollectFlags) error {
 	l := c.setup()
 
 	cConf := collector.Config{
 		Source:            c.Source,
 		Period:            flags.Period,
 		CachePath:         c.InsightsDir,
-		SourceMetricsPath: metricsPath,
+		SourceMetricsPath: flags.SourceMetricsPath,
+		SourceMetricsJSON: flags.SourceMetricsJSON,
 	}
 
 	cm := consent.New(l, c.ConsentDir)

--- a/insights/internal/collector/testdata/TestCompile/golden/with_sourcemetrics_json
+++ b/insights/internal/collector/testdata/TestCompile/golden/with_sourcemetrics_json
@@ -1,0 +1,11 @@
+{
+  "insightsVersion": "Tests",
+  "collectionTime": 10,
+  "systemInfo": {
+    "hardware": {},
+    "software": {}
+  },
+  "sourceMetrics": {
+    "test": "sourceMetricsJson"
+  }
+}


### PR DESCRIPTION
This PR implements the ability for both the C and Go APIs to directly pass a JSON object when calling collect, instead of forcing it to first write the JSON it wishes to pass to a file and passing the path instead.

Note that this PR makes no changes to the CLI.

There is also a small refactoring of the C API just to make it a little easier to modify and maintain.

---
[UDENG-7222](https://warthogs.atlassian.net/browse/UDENG-7222)

[UDENG-7222]: https://warthogs.atlassian.net/browse/UDENG-7222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ