### PR TITLE
refactor: Marshal OptOutJSON at init

### DIFF
--- a/insights/internal/collector/collector.go
+++ b/insights/internal/collector/collector.go
@@ -239,10 +239,7 @@ func (c collector) Write(insights Insights, dryRun bool) (err error) {
 		c.log.Info("Consent granted, writing insights report")
 	} else {
 		c.log.Warn("Insights data will not be written to disk, as consent was not provided.")
-		data, err = json.Marshal(constants.OptOutJSON)
-		if err != nil {
-			return fmt.Errorf("failed to marshal opt-out JSON: %v", err)
-		}
+		data = constants.OptOutPayload
 	}
 
 	if dryRun {

--- a/insights/internal/constants/constants.go
+++ b/insights/internal/constants/constants.go
@@ -3,6 +3,7 @@
 package constants
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,11 +60,19 @@ var (
 	DefaultCachePath = DefaultAppFolder
 	// OptOutJSON is the data sent in case of Opt-Out choice.
 	OptOutJSON = struct{ OptOut bool }{true}
+	// OptOutPayload is the marshalled version of OptOutJSON.
+	OptOutPayload []byte
 )
 
 func init() {
-	// This is to ensure that the man pages which include the default values
-	// are not generated with the home path at time of generation.
+	initalizePaths()
+	initializeOptOutPayload()
+}
+
+// initalizePaths initializes the default configuration and cache paths based on the user's home directory.
+// If the manGeneration variable is set to "true", it will clear the path variables to avoid including potentially
+// misleading paths in the generated man pages.
+func initalizePaths() {
 	if manGeneration == "true" {
 		DefaultConfigPath = ""
 		DefaultCachePath = ""
@@ -81,4 +90,13 @@ func init() {
 
 	DefaultConfigPath = filepath.Join(userConfigDir, DefaultConfigPath)
 	DefaultCachePath = filepath.Join(userCacheDir, DefaultCachePath)
+}
+
+// initializeOptOutPayload initializes the OptOutPayload variable with the marshalled OptOutJSON.
+func initializeOptOutPayload() {
+	var err error
+	OptOutPayload, err = json.Marshal(OptOutJSON)
+	if err != nil {
+		panic(fmt.Sprintf("Could not marshal OptOutJSON: %v", err))
+	}
 }

--- a/insights/internal/uploader/upload.go
+++ b/insights/internal/uploader/upload.go
@@ -2,7 +2,6 @@ package uploader
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -170,10 +169,7 @@ func (um Uploader) upload(r report.Report, uploadedDir, url string, consent, for
 	}
 	data := origData
 	if !consent {
-		data, err = json.Marshal(constants.OptOutJSON)
-		if err != nil {
-			return fmt.Errorf("failed to marshal opt-out JSON data: %v", err)
-		}
+		data = constants.OptOutPayload
 	}
 	um.log.Debug("Uploading", "payload", data)
 


### PR DESCRIPTION
This PR refactors the marshalling of OptOutJSON to instead happen at the init of `constants` instead of leaving it up to the user. Since it is considered a catastrophic failure if the marshalling fails, and since the marshalling failure should only happen if `constants.OptOutJSON` invalid, on marshalling failure, Ubuntu Insights will panic.

To separate concerns, the initialization of `OptOutPayload` and the path variables have been separated into independent functions.