### PR TITLE
fix: Build licenserecon from source for lrc-qa workflow

### DIFF
--- a/.github/workflows/lrc-qa.yaml
+++ b/.github/workflows/lrc-qa.yaml
@@ -1,34 +1,99 @@
 name: Validate debian/copyright
 
 env:
-  apt_deps: "licenserecon"
+  lrc_build_deps: "build-essential debhelper-compat fp-compiler fp-units-fcl fp-utils"
+  licenserecon_repo: "https://git.launchpad.net/ubuntu/+source/licenserecon"
+  licenserecon_branch: "applied/ubuntu/devel"
 
-# on:
-#   push:
-#     branches:
-#       - main
-#     tags:
-#       - "*"
-#   pull_request:
-#     paths:
-#       - "debian/copyright"
-#       - "debian/lrc.config"
-#       - "go.mod"
-on: [workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+    paths:
+      - "insights/debian/copyright"
+      - "insights/debian/lrc.config"
+      - "insights/go.mod"
+  workflow_dispatch:
 
 jobs:
   run-lrc:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Install dependencies
+      - name: Get latest licenserecon commit hash
+        id: licenserecon-commit
+        run: |
+          if COMMIT_HASH=$(git ls-remote ${{ env.licenserecon_repo }} ${{ env.licenserecon_branch }} | cut -f1); then
+            echo "hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
+            echo "cache-enabled=true" >> $GITHUB_OUTPUT
+            echo "Latest licenserecon commit: $COMMIT_HASH"
+          else
+            echo "::warning::Failed to get latest licenserecon commit hash, proceeding without cache"
+            echo "hash=fallback-$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+            echo "cache-enabled=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Cache licenserecon build - restore
+        uses: actions/cache/restore@v4
+        id: cache-licenserecon-restore
+        if: steps.licenserecon-commit.outputs.cache-enabled == 'true'
+        with:
+          path: licenserecon_*.deb
+          key: ${{ runner.os }}-licenserecon-${{ steps.licenserecon-commit.outputs.hash }}
+          restore-keys: |
+            ${{ runner.os }}-licenserecon-
+
+      - name: Install build dependencies
+        if: steps.licenserecon-commit.outputs.cache-enabled == 'false' || steps.cache-licenserecon-restore.outputs.cache-hit != 'true'
         run: |
           sudo apt update
-          sudo apt install -y ${{ env.apt_deps }}
+          sudo apt install -y ${{ env.lrc_build_deps }}
+
+      - name: Clone and build licenserecon
+        id: build-licenserecon
+        if: steps.licenserecon-commit.outputs.cache-enabled == 'false' || steps.cache-licenserecon-restore.outputs.cache-hit != 'true'
+        run: |
+          git clone -b ${{ env.licenserecon_branch }} ${{ env.licenserecon_repo }}
+          cd licenserecon
+          dpkg-buildpackage -us -uc -b
+
+      - name: Install licenserecon
+        run: |
+          sudo dpkg -i licenserecon_*.deb || sudo apt-get install -f -y
+
+      - name: Cache licenserecon build - save # Save licenserecon to cache even if `lrc` fails down the road.
+        uses: actions/cache/save@v4
+        if: steps.licenserecon-commit.outputs.cache-enabled == 'true' && steps.cache-licenserecon-restore.outputs.cache-hit != 'true' && steps.build-licenserecon.outcome == 'success'
+        with:
+          path: licenserecon_*.deb
+          key: ${{ runner.os }}-licenserecon-${{ steps.licenserecon-commit.outputs.hash }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: setup-go cache workaround #https://github.com/actions/setup-go/issues/424
+        shell: bash
+        run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.work
+          cache-dependency-path: |
+            insights/go.sum
+            server/go.sum
+            common/go.sum
+            tools/go.sum
+            go.work.sum
+
       - name: Vendor Go modules
+        working-directory: insights
+        env:
+          GOWORK: off
         run: |
           go mod vendor
+
       - name: Run lrc
+        working-directory: insights
         run: |
           lrc


### PR DESCRIPTION
This PR implements building `licenserecon` from source for the lrc-qa workflow.

As described in #126, the version of `licenserecon` available in the archive is not sufficient for our needs. Thus, this PR updates the `lrc-qa` workflow to now pull from the devel branch on launchpad directly to build it locally. It also updates the workflow to work with the new project structure.

To speed things up, caching is used by using the latest commit hash in the `applied/ubuntu/devel` branch as the cache key. If there is a cache hit, we restore the built `licenserecon` deb file and skip cloning and building. If there is not, then we pull and build locally. Note that even if `lrc` fails, we save the newly built `licenserecon` deb file to the cache after confirming that it can be installed successfully.

This PR also adds the `setup-go` action as a step before vendoring to take advantage of more caching.

Note that the action may be triggered via a workflow dispatch. While not really necessary to include, it is useful for debugging. 

See this run for an example of a workflow run with cache misses: https://github.com/ubuntu/ubuntu-insights/actions/runs/15882080221
See this run for an example of a workflow run with cache hits (~1 minute difference): https://github.com/ubuntu/ubuntu-insights/actions/runs/15882233362

----
https://warthogs.atlassian.net/jira/software/c/projects/UDENG/boards/1184?assignee=712020%3Aeba250b7-35d6-4795-af4f-5285be7d749f