### PR TITLE
feat: Database optimizations

### DIFF
--- a/server/migrations/000001_initialize-invalid_reports.up.sql
+++ b/server/migrations/000001_initialize-invalid_reports.up.sql
@@ -1,5 +1,4 @@
 CREATE TABLE invalid_reports (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     app_name TEXT NOT NULL,

--- a/server/migrations/000002_initialize-linux.down.sql
+++ b/server/migrations/000002_initialize-linux.down.sql
@@ -1,10 +1,9 @@
-DROP INDEX IF EXISTS idx_linux_optout;
+DROP INDEX IF EXISTS idx_linux_entry_time_optout;
 DROP INDEX IF EXISTS idx_linux_source_metrics;
 DROP INDEX IF EXISTS idx_linux_platform;
 DROP INDEX IF EXISTS idx_linux_software;
 DROP INDEX IF EXISTS idx_linux_hardware;
 DROP INDEX IF EXISTS idx_linux_collection_time;
-DROP INDEX IF EXISTS idx_linux_entry_time;
 DROP INDEX IF EXISTS idx_linux_report_id;
 
 DROP TABLE IF EXISTS linux;

--- a/server/migrations/000002_initialize-linux.up.sql
+++ b/server/migrations/000002_initialize-linux.up.sql
@@ -11,10 +11,9 @@ CREATE TABLE linux (
 );
 
 CREATE INDEX idx_linux_report_id ON linux(report_id);
-CREATE INDEX idx_linux_entry_time ON linux(entry_time);
+CREATE INDEX idx_linux_entry_time_optout ON linux(entry_time, optout);
 CREATE INDEX idx_linux_collection_time ON linux(collection_time);
 CREATE INDEX idx_linux_hardware ON linux USING gin (hardware);
 CREATE INDEX idx_linux_software ON linux USING gin (software);
 CREATE INDEX idx_linux_platform ON linux USING gin (platform);
 CREATE INDEX idx_linux_source_metrics ON linux USING gin (source_metrics);
-CREATE INDEX idx_linux_optout ON linux(optout);

--- a/server/migrations/000002_initialize-linux.up.sql
+++ b/server/migrations/000002_initialize-linux.up.sql
@@ -1,5 +1,4 @@
 CREATE TABLE linux (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     insights_version TEXT,

--- a/server/migrations/000003_initialize-windows.down.sql
+++ b/server/migrations/000003_initialize-windows.down.sql
@@ -1,10 +1,9 @@
-DROP INDEX IF EXISTS idx_windows_optout;
+DROP INDEX IF EXISTS idx_windows_entry_time_optout;
 DROP INDEX IF EXISTS idx_windows_source_metrics;
 DROP INDEX IF EXISTS idx_windows_platform;
 DROP INDEX IF EXISTS idx_windows_software;
 DROP INDEX IF EXISTS idx_windows_hardware;
 DROP INDEX IF EXISTS idx_windows_collection_time;
-DROP INDEX IF EXISTS idx_windows_entry_time;
 DROP INDEX IF EXISTS idx_windows_report_id;
 
 DROP TABLE IF EXISTS windows;

--- a/server/migrations/000003_initialize-windows.up.sql
+++ b/server/migrations/000003_initialize-windows.up.sql
@@ -11,10 +11,9 @@ CREATE TABLE windows (
 );
 
 CREATE INDEX idx_windows_report_id ON windows(report_id);
-CREATE INDEX idx_windows_entry_time ON windows(entry_time);
+CREATE INDEX idx_windows_entry_time_optout ON windows(entry_time, optout);
 CREATE INDEX idx_windows_collection_time ON windows(collection_time);
 CREATE INDEX idx_windows_hardware ON windows USING gin (hardware);
 CREATE INDEX idx_windows_software ON windows USING gin (software);
 CREATE INDEX idx_windows_platform ON windows USING gin (platform);
 CREATE INDEX idx_windows_source_metrics ON windows USING gin (source_metrics);
-CREATE INDEX idx_windows_optout ON windows(optout);

--- a/server/migrations/000003_initialize-windows.up.sql
+++ b/server/migrations/000003_initialize-windows.up.sql
@@ -1,5 +1,4 @@
 CREATE TABLE windows (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     insights_version TEXT,

--- a/server/migrations/000004_initialize-darwin.down.sql
+++ b/server/migrations/000004_initialize-darwin.down.sql
@@ -1,10 +1,9 @@
-DROP INDEX IF EXISTS idx_darwin_optout;
+DROP INDEX IF EXISTS idx_darwin_entry_time_optout;
 DROP INDEX IF EXISTS idx_darwin_source_metrics;
 DROP INDEX IF EXISTS idx_darwin_platform;
 DROP INDEX IF EXISTS idx_darwin_software;
 DROP INDEX IF EXISTS idx_darwin_hardware;
 DROP INDEX IF EXISTS idx_darwin_collection_time;
-DROP INDEX IF EXISTS idx_darwin_entry_time;
 DROP INDEX IF EXISTS idx_darwin_report_id;
 
 DROP TABLE IF EXISTS darwin;

--- a/server/migrations/000004_initialize-darwin.up.sql
+++ b/server/migrations/000004_initialize-darwin.up.sql
@@ -1,5 +1,4 @@
 CREATE TABLE darwin (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     insights_version TEXT,

--- a/server/migrations/000004_initialize-darwin.up.sql
+++ b/server/migrations/000004_initialize-darwin.up.sql
@@ -11,10 +11,9 @@ CREATE TABLE darwin (
 );
 
 CREATE INDEX idx_darwin_report_id ON darwin(report_id);
-CREATE INDEX idx_darwin_entry_time ON darwin(entry_time);
+CREATE INDEX idx_darwin_entry_time_optout ON darwin(entry_time, optout);
 CREATE INDEX idx_darwin_collection_time ON darwin(collection_time);
 CREATE INDEX idx_darwin_hardware ON darwin USING gin (hardware);
 CREATE INDEX idx_darwin_software ON darwin USING gin (software);
 CREATE INDEX idx_darwin_platform ON darwin USING gin (platform);
 CREATE INDEX idx_darwin_source_metrics ON darwin USING gin (source_metrics);
-CREATE INDEX idx_darwin_optout ON darwin(optout);

--- a/server/migrations/000005_initialize-ubuntu_report.down.sql
+++ b/server/migrations/000005_initialize-ubuntu_report.down.sql
@@ -1,8 +1,6 @@
-DROP INDEX IF EXISTS idx_ubuntu_report_optout;
+DROP INDEX IF EXISTS idx_ubuntu_report_entry_time_optout;
 
 DROP INDEX IF EXISTS idx_ubuntu_report_report;
-
-DROP INDEX IF EXISTS idx_ubuntu_report_entry_time;
 
 DROP INDEX IF EXISTS idx_ubuntu_report_report_id;
 

--- a/server/migrations/000005_initialize-ubuntu_report.up.sql
+++ b/server/migrations/000005_initialize-ubuntu_report.up.sql
@@ -1,5 +1,4 @@
 CREATE TABLE ubuntu_report (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     report_id UUID NOT NULL,
     entry_time TIMESTAMP NOT NULL,
     distribution TEXT NOT NULL,

--- a/server/migrations/000005_initialize-ubuntu_report.up.sql
+++ b/server/migrations/000005_initialize-ubuntu_report.up.sql
@@ -7,7 +7,6 @@ CREATE TABLE ubuntu_report (
     optout BOOLEAN NOT NULL
 );
 
-CREATE INDEX idx_ubuntu_report_entry_time ON ubuntu_report(entry_time);
-CREATE INDEX idx_ubuntu_report_optout ON ubuntu_report(optout);
+CREATE INDEX idx_ubuntu_report_entry_time_optout ON ubuntu_report(entry_time, optout);
 CREATE INDEX idx_ubuntu_report_report ON ubuntu_report USING gin (report);
 CREATE INDEX idx_ubuntu_report_report_id ON ubuntu_report(report_id);


### PR DESCRIPTION
This PR implements two database optimizations into the existing migration scripts:
 - Remove the unnecessary `id` primary key from all tables
   - There shouldn't be a scenario where we need a unique primary key. This removes a tiny amount of overhead when inserting, as well as the storage requirements for the column and index
 - Combine the `entry_time` and `optout` indexes into a single multi-column index
   - It is rare that we will ever need to query the entire history of the database, and we save some storage space by combining the two indexes into a single index
  
  ---
  [UDENG-7283](https://warthogs.atlassian.net/browse/UDENG-7283)

[UDENG-7283]: https://warthogs.atlassian.net/browse/UDENG-7283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ