### PR TITLE
feat: Add migration scripts for wsl_setup and ubuntu_desktop_provision tables

### DIFF
--- a/server/cmd/ingest-service/daemon/testdata/TestMigrateRequiresDirArgument/golden/basic_migration
+++ b/server/cmd/ingest-service/daemon/testdata/TestMigrateRequiresDirArgument/golden/basic_migration
@@ -2,5 +2,7 @@
 - linux
 - windows
 - darwin
-- schema_migrations
 - ubuntu_report
+- schema_migrations
+- wsl_setup
+- ubuntu_desktop_provision

--- a/server/cmd/ingest-service/daemon/testdata/TestMigrateRequiresDirArgument/golden/pre-applied_migrations
+++ b/server/cmd/ingest-service/daemon/testdata/TestMigrateRequiresDirArgument/golden/pre-applied_migrations
@@ -2,5 +2,7 @@
 - linux
 - windows
 - darwin
-- schema_migrations
 - ubuntu_report
+- schema_migrations
+- wsl_setup
+- ubuntu_desktop_provision

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/all_valid_apps
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/all_valid_apps
@@ -11,6 +11,11 @@
       "OptOutReports": 2,
       "OptInReports": 5
     },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
     "ubuntu_report": {
       "TotalReports": 0,
       "OptOutReports": 0,
@@ -20,6 +25,11 @@
       "TotalReports": 6,
       "OptOutReports": 3,
       "OptInReports": 3
+    },
+    "wsl_setup": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
     }
   },
   "InvalidReports": null

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/legacy_ubuntu_report_apps
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/legacy_ubuntu_report_apps
@@ -21,12 +21,22 @@
       "OptOutReports": 0,
       "OptInReports": 0
     },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
     "ubuntu_report": {
       "TotalReports": 12,
       "OptOutReports": 6,
       "OptInReports": 6
     },
     "windows": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
+    "wsl_setup": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/new_reports_only
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/new_reports_only
@@ -11,6 +11,11 @@
       "OptOutReports": 2,
       "OptInReports": 5
     },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
     "ubuntu_report": {
       "TotalReports": 0,
       "OptOutReports": 0,
@@ -19,6 +24,11 @@
     "windows": {
       "TotalReports": 3,
       "OptOutReports": 3,
+      "OptInReports": 0
+    },
+    "wsl_setup": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
       "OptInReports": 0
     }
   },

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/only_linux_valid
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/only_linux_valid
@@ -22,12 +22,22 @@
       "OptOutReports": 7,
       "OptInReports": 5
     },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
     "ubuntu_report": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0
     },
     "windows": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
+    "wsl_setup": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/preexisting_and_new_reports
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/preexisting_and_new_reports
@@ -11,6 +11,11 @@
       "OptOutReports": 7,
       "OptInReports": 10
     },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
     "ubuntu_report": {
       "TotalReports": 0,
       "OptOutReports": 0,
@@ -19,6 +24,11 @@
     "windows": {
       "TotalReports": 3,
       "OptOutReports": 3,
+      "OptInReports": 0
+    },
+    "wsl_setup": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
       "OptInReports": 0
     }
   },

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/preexisting_reports_only
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/preexisting_reports_only
@@ -11,6 +11,11 @@
       "OptOutReports": 2,
       "OptInReports": 5
     },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
     "ubuntu_report": {
       "TotalReports": 0,
       "OptOutReports": 0,
@@ -19,6 +24,11 @@
     "windows": {
       "TotalReports": 3,
       "OptOutReports": 3,
+      "OptInReports": 0
+    },
+    "wsl_setup": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
       "OptInReports": 0
     }
   },

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_invalid_json
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_invalid_json
@@ -11,12 +11,22 @@
       "OptOutReports": 0,
       "OptInReports": 1
     },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
     "ubuntu_report": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0
     },
     "windows": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
+    "wsl_setup": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_unexpected_fields
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_unexpected_fields
@@ -11,6 +11,11 @@
       "OptOutReports": 0,
       "OptInReports": 3
     },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
     "ubuntu_report": {
       "TotalReports": 1,
       "OptOutReports": 1,
@@ -19,6 +24,11 @@
     "windows": {
       "TotalReports": 1,
       "OptOutReports": 1,
+      "OptInReports": 0
+    },
+    "wsl_setup": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
       "OptInReports": 0
     }
   },

--- a/server/cmd/ingest-service/integration-tests/testdata/TestMigrate/golden/basic_migration
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestMigrate/golden/basic_migration
@@ -2,5 +2,7 @@
 - linux
 - windows
 - darwin
-- schema_migrations
 - ubuntu_report
+- schema_migrations
+- wsl_setup
+- ubuntu_desktop_provision

--- a/server/cmd/ingest-service/integration-tests/testdata/TestMigrate/golden/pre-applied_migrations
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestMigrate/golden/pre-applied_migrations
@@ -2,5 +2,7 @@
 - linux
 - windows
 - darwin
-- schema_migrations
 - ubuntu_report
+- schema_migrations
+- wsl_setup
+- ubuntu_desktop_provision

--- a/server/migrations/000006_initialize-wsl_setup.down.sql
+++ b/server/migrations/000006_initialize-wsl_setup.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_wsl_setup_entry_time_optout;
+DROP INDEX IF EXISTS idx_wsl_setup_source_metrics;
+DROP INDEX IF EXISTS idx_wsl_setup_platform;
+DROP INDEX IF EXISTS idx_wsl_setup_software;
+DROP INDEX IF EXISTS idx_wsl_setup_hardware;
+DROP INDEX IF EXISTS idx_wsl_setup_collection_time;
+DROP INDEX IF EXISTS idx_wsl_setup_report_id;
+
+DROP TABLE IF EXISTS wsl_setup;

--- a/server/migrations/000006_initialize-wsl_setup.up.sql
+++ b/server/migrations/000006_initialize-wsl_setup.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE wsl_setup (
+    report_id UUID NOT NULL,
+    entry_time TIMESTAMP NOT NULL,
+    insights_version TEXT,
+    collection_time TIMESTAMP,
+    hardware JSONB,
+    software JSONB,
+    platform JSONB,
+    source_metrics JSONB,
+    optout BOOLEAN NOT NULL
+);
+
+CREATE INDEX idx_wsl_setup_report_id ON wsl_setup(report_id);
+CREATE INDEX idx_wsl_setup_entry_time_optout ON wsl_setup(entry_time, optout);
+CREATE INDEX idx_wsl_setup_collection_time ON wsl_setup(collection_time);
+CREATE INDEX idx_wsl_setup_hardware ON wsl_setup USING gin (hardware);
+CREATE INDEX idx_wsl_setup_software ON wsl_setup USING gin (software);
+CREATE INDEX idx_wsl_setup_platform ON wsl_setup USING gin (platform);
+CREATE INDEX idx_wsl_setup_source_metrics ON wsl_setup USING gin (source_metrics);

--- a/server/migrations/000007_initialize-ubuntu_desktop_provision.down.sql
+++ b/server/migrations/000007_initialize-ubuntu_desktop_provision.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_ubuntu_desktop_provision_entry_time_optout;
+DROP INDEX IF EXISTS idx_ubuntu_desktop_provision_source_metrics;
+DROP INDEX IF EXISTS idx_ubuntu_desktop_provision_platform;
+DROP INDEX IF EXISTS idx_ubuntu_desktop_provision_software;
+DROP INDEX IF EXISTS idx_ubuntu_desktop_provision_hardware;
+DROP INDEX IF EXISTS idx_ubuntu_desktop_provision_collection_time;
+DROP INDEX IF EXISTS idx_ubuntu_desktop_provision_report_id;
+
+DROP TABLE IF EXISTS ubuntu_desktop_provision;

--- a/server/migrations/000007_initialize-ubuntu_desktop_provision.up.sql
+++ b/server/migrations/000007_initialize-ubuntu_desktop_provision.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE ubuntu_desktop_provision (
+    report_id UUID NOT NULL,
+    entry_time TIMESTAMP NOT NULL,
+    insights_version TEXT,
+    collection_time TIMESTAMP,
+    hardware JSONB,
+    software JSONB,
+    platform JSONB,
+    source_metrics JSONB,
+    optout BOOLEAN NOT NULL
+);
+
+CREATE INDEX idx_ubuntu_desktop_provision_report_id ON ubuntu_desktop_provision(report_id);
+CREATE INDEX idx_ubuntu_desktop_provision_entry_time_optout ON ubuntu_desktop_provision(entry_time, optout);
+CREATE INDEX idx_ubuntu_desktop_provision_collection_time ON ubuntu_desktop_provision(collection_time);
+CREATE INDEX idx_ubuntu_desktop_provision_hardware ON ubuntu_desktop_provision USING gin (hardware);
+CREATE INDEX idx_ubuntu_desktop_provision_software ON ubuntu_desktop_provision USING gin (software);
+CREATE INDEX idx_ubuntu_desktop_provision_platform ON ubuntu_desktop_provision USING gin (platform);
+CREATE INDEX idx_ubuntu_desktop_provision_source_metrics ON ubuntu_desktop_provision USING gin (source_metrics);


### PR DESCRIPTION
This PR adds migration scripts for `wsl_setup` and `ubuntu_desktop_provision` and updates golden files where needed.

https://github.com/ubuntu/wsl-setup
https://github.com/canonical/ubuntu-desktop-provision

No new tests specific to these two new apps were added, but the existing tests should be sufficient to ensure that migrations up work, and that it is possible to query them.

---
[UDENG-7283](https://warthogs.atlassian.net/browse/UDENG-7283)

[UDENG-7283]: https://warthogs.atlassian.net/browse/UDENG-7283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ