### PR TITLE
tests: ubuntu-insights debian package tests

### DIFF
--- a/.github/workflows/qa-debian.yaml
+++ b/.github/workflows/qa-debian.yaml
@@ -1,0 +1,64 @@
+name: Build and run trivial debian package tests
+# Builds the client debian package on ubuntu:devel and attempt to install it locally to run a set of toy tests.
+
+on:
+  pull_request:
+    paths-ignore:
+      - server/**
+      - tools/**
+      - "*.md"
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  build-ubuntu-insights:
+    name: Build ubuntu-insights debian package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build debian package
+        uses: canonical/desktop-engineering/gh-actions/common/build-debian@main
+        with:
+          source-dir: insights
+          token: ${{ secrets.GITHUB_TOKEN }}
+          docker-image: ubuntu:devel
+
+  qa:
+    name: Run trivial debian package tests
+    runs-on: ubuntu-latest
+    needs: build-ubuntu-insights
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # name: is left blank so that all artifacts are downloaded
+          path: ci-artifacts
+
+      - name: Install ubuntu-insights debian package
+        run: |
+          sudo apt install -y ./ci-artifacts/ubuntu-insights_*-debian-packages/ubuntu-insights_*.deb
+
+      - name: Ensure man page is installed
+        run: |
+          MANPAGER=cat man ubuntu-insights
+
+      - name: Ensure systemd units are installed
+        run: |
+          # Verify systemd can find the units (will succeed even if inactive)
+          systemctl --user --no-pager list-unit-files ubuntu-insights-collect.service
+          systemctl --user --no-pager list-unit-files ubuntu-insights-collect.timer
+          systemctl --user --no-pager list-unit-files ubuntu-insights-upload.service
+          systemctl --user --no-pager list-unit-files ubuntu-insights-upload.timer
+
+      - name: Run trivial tests
+        run:
+          | # Go through a typical workflow, ensuring that no errors are encountered. This should eventually be replaced with true end-to-end tests.
+          ubuntu-insights --version
+          ubuntu-insights --help
+          ubuntu-insights collect -df
+          ubuntu-insights collect
+          ubuntu-insights consent -s=true
+          ubuntu-insights collect
+          ubuntu-insights upload -df


### PR DESCRIPTION
This PR implements a workflow to build the ubuntu insights debian package using the docker `ubuntu:devel` image, It then attempts to install the built .deb package before running some trivial tests. For instance, it verifies the installation of a man page, systemd units, and that the CLI roughly works (only ensures exit code 0 when running commands on the runner).

Besides these mostly toy tests, the workflow is useful for ensuring that the debian package builds correctly and that there are no lintian errors.

Ideally, more robust tests should be written in the future, but that is out of scope for now.

---
[UDENG-7226](https://warthogs.atlassian.net/browse/UDENG-7226)

[UDENG-7226]: https://warthogs.atlassian.net/browse/UDENG-7226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ