### PR TITLE
ci: Autopkgtest workflow

### DIFF
--- a/.github/workflows/qa-debian.yaml
+++ b/.github/workflows/qa-debian.yaml
@@ -1,5 +1,5 @@
-name: Build and run trivial debian package tests
-# Builds the client debian package on ubuntu:devel and attempt to install it locally to run a set of toy tests.
+name: Debian package tests
+# Builds the client debian package on ubuntu:devel and attempt to install it locally to run a set of toy tests as well as autopkgtest.
 
 on:
   pull_request:
@@ -15,6 +15,10 @@ jobs:
   build-ubuntu-insights:
     name: Build ubuntu-insights debian package
     runs-on: ubuntu-latest
+    outputs:
+      run-id: ${{ github.run_id }}
+      pkg-dsc-devel:  ${{ steps.outputs.outputs.pkg-dsc-devel }}
+      pkg-src-changes-devel: ${{ steps.outputs.outputs.pkg-src-changes-devel }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,6 +28,14 @@ jobs:
           source-dir: insights
           token: ${{ secrets.GITHUB_TOKEN }}
           docker-image: ubuntu:devel
+      
+      - name: Generate outputs
+        id: outputs
+        run: |
+          (
+            echo "pkg-dsc-devel=${{ env.PKG_DSC }}"
+            echo "pkg-src-changes-devel=${{ env.PKG_SOURCE_CHANGES }}"
+          ) >> "${GITHUB_OUTPUT}"
 
   qa:
     name: Run trivial debian package tests
@@ -62,3 +74,20 @@ jobs:
           ubuntu-insights consent -s=true
           ubuntu-insights collect
           ubuntu-insights upload -df
+
+  autopkgtest:
+    name: Run autopkgtest
+    runs-on: ubuntu-latest
+    needs: build-ubuntu-insights
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ needs.build-ubuntu-insights.outputs.run-id }}
+          merge-multiple: true
+
+      - name: Run autopkgtest
+        uses: canonical/desktop-engineering/gh-actions/common/run-autopkgtest@main
+        with:
+          lxd-image: ubuntu:devel
+          source-changes: ${{ needs.build-ubuntu-insights.outputs.pkg-src-changes-devel }}


### PR DESCRIPTION
This PR adds a job to the `qa-debian` workflow to run `autopkgtest` on the source output of the build Debian package job.

It also renames the workflow name to something a little shorter.

The GitHub Linux runners do seem to have universal [support for nested virtualization](https://github.com/orgs/community/discussions/160591#discussioncomment-9018826). But the user needs to be [added to the `kvm` group](https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/).  

`autopkgtest-buildvm-ubuntu-cloud` pulls the minimal latest development release of the distribution that we are calling from (presently, https://cloud-images.ubuntu.com/minimal/daily/questing/current/questing-minimal-cloudimg-amd64.img) which is what we are looking for, as we want Ubuntu Insights to always target the development release. The downside of doing this though is that caching isn't really possible, resulting in this workflow taking longer than all the others.

---
[UDENG-7294](https://warthogs.atlassian.net/browse/UDENG-7294)

[UDENG-7294]: https://warthogs.atlassian.net/browse/UDENG-7294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ