### PR TITLE
feat; Add distribution-version index to ubuntu_report table

### DIFF
--- a/server/migrations/000005_initialize-ubuntu_report.down.sql
+++ b/server/migrations/000005_initialize-ubuntu_report.down.sql
@@ -1,7 +1,6 @@
 DROP INDEX IF EXISTS idx_ubuntu_report_entry_time_optout;
-
+DROP INDEX IF EXISTS idx_ubuntu_report_distribution_version;
 DROP INDEX IF EXISTS idx_ubuntu_report_report;
-
 DROP INDEX IF EXISTS idx_ubuntu_report_report_id;
 
 DROP TABLE IF EXISTS ubuntu_report;

--- a/server/migrations/000005_initialize-ubuntu_report.up.sql
+++ b/server/migrations/000005_initialize-ubuntu_report.up.sql
@@ -7,6 +7,7 @@ CREATE TABLE ubuntu_report (
     optout BOOLEAN NOT NULL
 );
 
-CREATE INDEX idx_ubuntu_report_entry_time_optout ON ubuntu_report(entry_time, optout);
-CREATE INDEX idx_ubuntu_report_report ON ubuntu_report USING gin (report);
 CREATE INDEX idx_ubuntu_report_report_id ON ubuntu_report(report_id);
+CREATE INDEX idx_ubuntu_report_entry_time_optout ON ubuntu_report(entry_time, optout);
+CREATE INDEX idx_ubuntu_report_distribution_version ON ubuntu_report(distribution, version);
+CREATE INDEX idx_ubuntu_report_report ON ubuntu_report USING gin (report);

--- a/server/migrations/000006_initialize-wsl_setup.down.sql
+++ b/server/migrations/000006_initialize-wsl_setup.down.sql
@@ -1,9 +1,9 @@
+DROP INDEX IF EXISTS idx_wsl_setup_report_id;
 DROP INDEX IF EXISTS idx_wsl_setup_entry_time_optout;
 DROP INDEX IF EXISTS idx_wsl_setup_source_metrics;
 DROP INDEX IF EXISTS idx_wsl_setup_platform;
 DROP INDEX IF EXISTS idx_wsl_setup_software;
 DROP INDEX IF EXISTS idx_wsl_setup_hardware;
 DROP INDEX IF EXISTS idx_wsl_setup_collection_time;
-DROP INDEX IF EXISTS idx_wsl_setup_report_id;
 
 DROP TABLE IF EXISTS wsl_setup;


### PR DESCRIPTION
Small fix to add a missing index for the distribution and version column on the `ubuntu_report` table. Given that the two columns will likely always be used together, the index added is a multi-column index with distribution as the major and version as the minor.

For the sake of the downstream rock, after merging this PR, tag v0.1.1 will be pushed. 