### PR TITLE
feat: Go API Collect returns report 

### DIFF
--- a/insights/C/libinsights.go
+++ b/insights/C/libinsights.go
@@ -24,7 +24,8 @@ import (
 //export collectInsights
 func collectInsights(config *C.CInsightsConfig, source *C.char, flags *C.CCollectFlags) *C.char {
 	return collectCustomInsights(config, source, flags, func(conf insights.Config, source string, f insights.CollectFlags) error {
-		return conf.Collect(source, f)
+		_, err := conf.Collect(source, f)
+		return err
 	})
 }
 


### PR DESCRIPTION
This PR changes the Go API such that the Collect method returns the compiled report in a pretty printed JSON byte slice format. Note that since it is returning the compiled report, what is actually written to disk may differ based on the provided flags or the current consent state. For example, if consent is false, Collect will still return a full report, but an OptOut payload will be written to disk.

In combination with #158, these changes mark tagged version 0.2.0, but do not necessitate a new Debian package release.

---
[UDENG-7280](https://warthogs.atlassian.net/browse/UDENG-7280)

[UDENG-7280]: https://warthogs.atlassian.net/browse/UDENG-7280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ