### PR TITLE
maint: remove authd reference when running autopkgtests

### DIFF
--- a/insights/debian/tests/run-tests.sh
+++ b/insights/debian/tests/run-tests.sh
@@ -2,7 +2,6 @@
 
 set -exuo pipefail
 
-export AUTHD_SKIP_EXTERNAL_DEPENDENT_TESTS=1
 export GOPROXY=off
 export GOTOOLCHAIN=local
 


### PR DESCRIPTION
It seems that part was taken from another repo. This environment variable has no effect on the current project.