### PR TITLE
maint: remove copyright duplication

### DIFF
--- a/insights/debian/copyright
+++ b/insights/debian/copyright
@@ -8,11 +8,6 @@ Copyright: 2025, Canonical Ltd
 License: GPL-3
 Comment: Debian packaging is licensed under the same terms as upstream
 
-Files: debian/*
-Copyright: 2025, Canonical Ltd
-License: GPL-3
-Comment: Debian packaging is licensed under the same terms as upstream
-
 Files: vendor/github.com/BurntSushi/toml/*
 Copyright: 2013, TOML authors
 License: Expat


### PR DESCRIPTION
The comment already states that the packaging is using the same license. Anyway, even without it, the pattern format is already covering it. Also, for a native package, this is standard to not split the packaging from the source.