### PR TITLE
build: Bump changelog to 0.2.0 for release

### DIFF
--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -1,8 +1,11 @@
-ubuntu-insights (0.2.0~ppa3) questing; urgency=medium
+ubuntu-insights (0.2.0) questing; urgency=medium
 
   * Fix armhf builds
+  * Upgrades various golang dependencies
+  * Fix copyright duplication
+  * Cleanup unnecessary reference in run-tests.sh script
 
- -- Kat Kuo <kat.kuo@canonical.com>  Wed, 09 Jul 2025 10:35:31 -0400
+ -- Kat Kuo <kat.kuo@canonical.com>  Mon, 14 Jul 2025 13:23:43 -0400
 
 ubuntu-insights (0.1.0) questing; urgency=medium
 


### PR DESCRIPTION
This PR bumps the changelog version to a native 0.2.0. It is to be merged just before uploading the Debian package downstream. Once merged, tag `v0.2.0` should be associated with the merge commit on main.

In addition to being a client release to be uploaded to Launchpad, the tagged version `v0.2.0` includes changes relevant in the API/bindings and server contexts.
- Debian Package
  - Fixed armhf builds
- Client API/C bindings
	- Go API specific
	  - Replace passing of verbosity level with optional passing of a slogger object.
	  - Consent getter now returns (bool, error) instead of a custom enum.
	  - Collect now returns the report in a manner like the CLI printing the compiled report on collect.
	- Both the Go API and C bindings
	  - Upload now takes a list of sources instead of a single string source.
	  - Changed default sloggers to text handlers at an info level.
	  - Move source(s) out of the config object/struct and directly into the method definitions. 
- Server
  - Added missing index to `ubuntu_report` table.
  - Breaking changes to the SQL migration scripts. Migrations need to be reapplied from a clean slate and cannot be merely run ontop of an existing database.
	  - Removed the `wsl_setup` app table


Blocked by #162 and #159.