### PR TITLE
ci: Update Dependabot for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
 
   ## Go dependencies
   - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
+    directory: "/insights"
     schedule:
       interval: "weekly"
       day: "thursday"
@@ -29,7 +29,33 @@ updates:
         #applies-to: version-updates
         update-types: ["minor", "patch"]
     commit-message:
-      prefix: "deps(go)"
+      prefix: "deps(go-insights)"
+
+  - package-ecosystem: "gomod"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "09:00"
+    groups:
+      minor-updates:
+        #applies-to: version-updates
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "deps(go-server)"
+
+  - package-ecosystem: "gomod"
+    directory: "/common"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "09:00"
+    groups:
+      minor-updates:
+        #applies-to: version-updates
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "deps(go-common)"
 
   - package-ecosystem: "gomod"
     directory: "/tools"


### PR DESCRIPTION
This PR updates the Dependabot configuration to work with the repository organization implemented in #144. Since it looks for go.mod only in the directory specified, we need to tell it about every individual module. For finer per-module control, this PR utilizes multiple `package-ecosystem` entries instead of a single entry with `directories`. This allows for things such as unique commit message prefixes per entry.

Note that Dependabot does not know how to handle `go.work`, and will not run `go work sync`. This is something we'd have to do manually every so often.