### PR TITLE
feat(server): Use map to search allow list where reasonable

### DIFF
--- a/server/internal/common/config/config.go
+++ b/server/internal/common/config/config.go
@@ -21,7 +21,7 @@ var reservedNames = map[string]struct{}{
 // Provider is an interface that defines methods to access configuration values.
 type Provider interface {
 	AllowList() []string
-	AllowSet() map[string]struct{}
+	Allows(string) bool
 }
 
 // Conf represents the configuration structure.
@@ -162,18 +162,21 @@ func (cm *Manager) Watch(ctx context.Context) (changes <-chan struct{}, errors <
 	return changesCh, errorsCh, nil
 }
 
-// AllowList returns the allow list from the configuration.
+// AllowList returns a copy of the allow list from the configuration.
 func (cm *Manager) AllowList() []string {
 	cm.lock.RLock()
 	defer cm.lock.RUnlock()
-	return cm.config.AllowedList
+	allowListCopy := make([]string, len(cm.config.AllowedList))
+	copy(allowListCopy, cm.config.AllowedList)
+	return allowListCopy
 }
 
-// AllowSet returns a set of allowed names for faster lookups.
-func (cm *Manager) AllowSet() map[string]struct{} {
+// Allows checks if the given value is in the allow set.
+func (cm *Manager) Allows(value string) bool {
 	cm.lock.RLock()
 	defer cm.lock.RUnlock()
-	return cm.allowSet
+	_, exists := cm.allowSet[value]
+	return exists
 }
 
 // filterAllowList filters out reserved names from the allow list.

--- a/server/internal/common/config/config.go
+++ b/server/internal/common/config/config.go
@@ -18,12 +18,6 @@ var reservedNames = map[string]struct{}{
 	"schema_migrations": {},
 }
 
-// Provider is an interface that defines methods to access configuration values.
-type Provider interface {
-	AllowList() []string
-	Allows(string) bool
-}
-
 // Conf represents the configuration structure.
 type Conf struct {
 	AllowedList []string `json:"allowList"`

--- a/server/internal/common/config/config.go
+++ b/server/internal/common/config/config.go
@@ -165,8 +165,8 @@ func (cm *Manager) AllowList() []string {
 	return allowListCopy
 }
 
-// Allows checks if the given value is in the allow set.
-func (cm *Manager) Allows(value string) bool {
+// IsAllowed checks if the given value is in the allow set.
+func (cm *Manager) IsAllowed(value string) bool {
 	cm.lock.RLock()
 	defer cm.lock.RUnlock()
 	_, exists := cm.allowSet[value]

--- a/server/internal/common/config/config_test.go
+++ b/server/internal/common/config/config_test.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -24,59 +23,80 @@ func createTempConfigFile(t *testing.T, content string) string {
 	return tmpFile
 }
 
-func TestLoadValidConfig(t *testing.T) {
+func TestLoad(t *testing.T) {
 	t.Parallel()
-	content := `{
-		"allowList": ["foo", "bar"]
-	}`
-	tmpFile := createTempConfigFile(t, content)
 
-	cm := config.New(tmpFile)
-	if err := cm.Load(); err != nil {
-		t.Fatalf("expected no error loading config, got %v", err)
+	tests := map[string]struct {
+		content     string
+		missingFile bool
+
+		wantErr bool
+	}{
+		"Valid config loads": {
+			content: `{"allowList": ["foo", "bar"]}`,
+		},
+		"Empty JSON loads": {
+			content: "{}",
+		},
+		"Ignores reserved names": {
+			content: func() string {
+				content := `{"allowList": ["foo"`
+				for reservedName := range config.GetReservedNames() {
+					content += fmt.Sprintf(`, "%s"`, reservedName)
+				}
+				content += `]}`
+				return content
+			}(),
+		},
+
+		// Error cases
+		"Invalid JSON fails": {
+			content: `{"allowList": ["foo", "bar"]`, // Missing closing brace
+			wantErr: true,
+		},
+		"Missing file fails": {
+			content:     "{}",
+			missingFile: true,
+			wantErr:     true,
+		},
+		"Empty file fails": {
+			wantErr: true,
+		},
 	}
 
-	expected := []string{"foo", "bar"}
-	if got := cm.AllowList(); !reflect.DeepEqual(got, expected) {
-		t.Errorf("expected allowList %v, got %v", expected, got)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			configPath := "nonexistent.json"
+			if !tc.missingFile {
+				configPath = createTempConfigFile(t, tc.content)
+			}
+
+			cm := config.New(configPath)
+			err := cm.Load()
+
+			if tc.wantErr {
+				require.Error(t, err, "expected error loading config")
+				assert.Empty(t, cm.AllowList(), "expected empty allowList on error")
+				assert.Empty(t, cm.AllowSet(), "expected empty allowSet on error")
+				return
+			}
+			require.NoError(t, err, "expected no error loading config")
+
+			got := struct {
+				AllowList []string
+				AllowSet  map[string]struct{}
+			}{
+				AllowList: cm.AllowList(),
+				AllowSet:  cm.AllowSet(),
+			}
+
+			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
+			assert.Equal(t, want.AllowList, got.AllowList, "expected allowList to match")
+			assert.Equal(t, want.AllowSet, got.AllowSet, "expected allowSet to match")
+		})
 	}
-}
-
-func TestLoadInvalidJSON(t *testing.T) {
-	t.Parallel()
-	content := `{
-		"allowList": ["foo", "bar"]` // Missing closing brace
-	tmpFile := createTempConfigFile(t, content)
-
-	cm := config.New(tmpFile)
-	require.Error(t, cm.Load(), "expected error loading malformed JSON")
-}
-
-func TestLoadMissingFile(t *testing.T) {
-	t.Parallel()
-	cm := config.New("nonexistent.json")
-	require.Error(t, cm.Load(), "expected error loading missing config file")
-}
-
-func TestLoadIgnoresReservedNames(t *testing.T) {
-	t.Parallel()
-	content := `{
-		"allowList": ["foo"`
-
-	for reservedName := range config.GetReservedNames() {
-		content += fmt.Sprintf(`, "%s"`, reservedName)
-	}
-	content += `]
-	}`
-
-	tmpFile := createTempConfigFile(t, content)
-
-	cm := config.New(tmpFile)
-	require.NoError(t, cm.Load(), "expected no error loading config with reserved names")
-
-	expected := []string{"foo"} // Reserved names should be ignored
-	got := cm.AllowList()
-	assert.Equal(t, expected, got, "expected allowList to ignore reserved names")
 }
 
 func TestWatchMissingFile(t *testing.T) {
@@ -110,9 +130,8 @@ func TestWatchConfigReloadsOnChange(t *testing.T) {
 
 	time.Sleep(time.Second) // let watcher reload
 
-	if got := cm.AllowList(); !reflect.DeepEqual(got, []string{"beta"}) {
-		t.Errorf("expected allowList [beta], got %v", got)
-	}
+	require.Equal(t, []string{"beta"}, cm.AllowList(), "expected allowList to match")
+	require.Equal(t, map[string]struct{}{"beta": {}}, cm.AllowSet(), "expected allowSet to match")
 
 	select {
 	case err := <-watchErr:
@@ -240,9 +259,8 @@ func TestWatchIgnoresReservedNames(t *testing.T) {
 	require.NoError(t, os.WriteFile(tmpFile, []byte(updated), 0600), "Setup: failed to write updated config with reserved names")
 	time.Sleep(time.Second) // let watcher reload
 
-	if got := cm.AllowList(); !reflect.DeepEqual(got, []string{"alpha"}) {
-		t.Errorf("expected allowList [beta], got %v", got)
-	}
+	require.Equal(t, []string{"alpha"}, cm.AllowList(), "expected allowList to match")
+	require.Equal(t, map[string]struct{}{"alpha": {}}, cm.AllowSet(), "expected allowSet to match")
 
 	select {
 	case err := <-watchErr:

--- a/server/internal/common/config/export_test.go
+++ b/server/internal/common/config/export_test.go
@@ -14,3 +14,10 @@ func WithLogger(l *slog.Logger) Options {
 func GetReservedNames() map[string]struct{} {
 	return reservedNames
 }
+
+// AllowSet returns the internal set of allowed names.
+func (cm *Manager) AllowSet() map[string]struct{} {
+	cm.lock.RLock()
+	defer cm.lock.RUnlock()
+	return cm.allowSet
+}

--- a/server/internal/common/config/testdata/TestLoad/golden/empty_json_loads
+++ b/server/internal/common/config/testdata/TestLoad/golden/empty_json_loads
@@ -1,0 +1,2 @@
+allowlist: []
+allowset: {}

--- a/server/internal/common/config/testdata/TestLoad/golden/ignores_reserved_names
+++ b/server/internal/common/config/testdata/TestLoad/golden/ignores_reserved_names
@@ -1,0 +1,4 @@
+allowlist:
+    - foo
+allowset:
+    foo: {}

--- a/server/internal/common/config/testdata/TestLoad/golden/valid_config_loads
+++ b/server/internal/common/config/testdata/TestLoad/golden/valid_config_loads
@@ -1,0 +1,6 @@
+allowlist:
+    - foo
+    - bar
+allowset:
+    bar: {}
+    foo: {}

--- a/server/internal/ingest/ingest.go
+++ b/server/internal/ingest/ingest.go
@@ -32,7 +32,7 @@ type Service struct {
 
 type dConfigManager interface {
 	Watch(context.Context) (<-chan struct{}, <-chan error, error)
-	AllowList() []string
+	AllowSet() map[string]struct{}
 }
 
 type dProcessor interface {
@@ -122,14 +122,10 @@ func (s *Service) Run() error {
 
 // syncWorkers diffs the allow‐list and starts/stops goroutines.
 func (s *Service) syncWorkers() {
-	allowed := s.cm.AllowList()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	want := map[string]struct{}{}
-	for _, app := range allowed {
-		want[app] = struct{}{}
-	}
+	want := s.cm.AllowSet()
 
 	// stop removed
 	for app, cancel := range s.workers {

--- a/server/internal/ingest/ingest.go
+++ b/server/internal/ingest/ingest.go
@@ -33,7 +33,7 @@ type Service struct {
 type dConfigManager interface {
 	Watch(context.Context) (<-chan struct{}, <-chan error, error)
 	AllowList() []string
-	Allows(string) bool
+	IsAllowed(string) bool
 }
 
 type dProcessor interface {
@@ -128,7 +128,7 @@ func (s *Service) syncWorkers() {
 
 	// stop removed
 	for app, cancel := range s.workers {
-		if !s.cm.Allows(app) {
+		if !s.cm.IsAllowed(app) {
 			cancel()
 			delete(s.workers, app)
 		}

--- a/server/internal/ingest/ingest_test.go
+++ b/server/internal/ingest/ingest_test.go
@@ -95,6 +95,11 @@ func TestRun(t *testing.T) {
 				tc.cm = newConfigManager()
 			}
 
+			// Apply the allowSet if not already set
+			if tc.cm.allowSet == nil {
+				tc.cm.allowSet = createSet(tc.cm.allowList...)
+			}
+
 			if tc.proc == nil {
 				tc.proc = newProcessor(map[string]error{})
 			}
@@ -124,21 +129,16 @@ func TestRun(t *testing.T) {
 func TestRunModifyAllowList(t *testing.T) {
 	t.Parallel()
 
-	cm := &mockConfigManager{
-		allowList: []string{"SingleValid"},
-
-		reloadCh: make(chan struct{}),
-		errCh:    make(chan error),
-	}
+	cm := newConfigManager("SingleValid")
 	s := ingest.New(t.Context(), cm, &mockDProcessor{})
 	runErr := run(t, s)
 
 	waitWorkersEqual(t, s, cm.AllowList()...)
 
-	cm.SetAllowList(t, append(cm.AllowList(), "MultiMixed"), 3)
+	cm.setAllowList(t, append(cm.AllowList(), "MultiMixed"), 3)
 	waitWorkersEqual(t, s, cm.AllowList()...)
 
-	cm.SetAllowList(t, []string{}, 3)
+	cm.setAllowList(t, []string{}, 3)
 	waitWorkersEqual(t, s)
 
 	gracefulShutdown(t, s, runErr)
@@ -147,12 +147,7 @@ func TestRunModifyAllowList(t *testing.T) {
 func TestRunAfterQuitErrors(t *testing.T) {
 	t.Parallel()
 
-	cm := &mockConfigManager{
-		allowList: []string{"SingleValid"},
-
-		reloadCh: make(chan struct{}),
-		errCh:    make(chan error),
-	}
+	cm := newConfigManager("SingleValid")
 	s := ingest.New(t.Context(), cm, &mockDProcessor{})
 	defer s.Quit(true)
 
@@ -256,13 +251,14 @@ func waitWorkersEqual(t *testing.T, s *ingest.Service, workers ...string) {
 		if slices.Equal(workers, got) {
 			return
 		}
-		require.LessOrEqual(t, time.Since(start), timeout, "Workers did not match within the timeout")
+		require.LessOrEqual(t, time.Since(start), timeout, "Workers did not match within the timeout. Wanted: %v, Got: %v", workers, got)
 		time.Sleep(delay)
 	}
 }
 
 type mockConfigManager struct {
 	allowList []string
+	allowSet  map[string]struct{}
 
 	closeReloadCh   bool
 	closeWatchErr   bool
@@ -278,6 +274,7 @@ type mockConfigManager struct {
 func newConfigManager(allowList ...string) *mockConfigManager {
 	return &mockConfigManager{
 		allowList: allowList,
+		allowSet:  createSet(allowList...),
 		reloadCh:  make(chan struct{}),
 		errCh:     make(chan error),
 	}
@@ -316,17 +313,32 @@ func (m *mockConfigManager) AllowList() []string {
 	return m.allowList
 }
 
-func (m *mockConfigManager) SetAllowList(t *testing.T, newAllowList []string, sendReloadSignal uint) {
+func (m *mockConfigManager) AllowSet() map[string]struct{} {
+	m.mu.RLock() // Lock for reading
+	defer m.mu.RUnlock()
+	return m.allowSet
+}
+
+func (m *mockConfigManager) setAllowList(t *testing.T, newAllowList []string, sendReloadSignal uint) {
 	t.Helper()
 
 	m.mu.Lock() // Lock for writing
 	defer m.mu.Unlock()
 	m.allowList = newAllowList
+	m.allowSet = createSet(newAllowList...)
 
 	for range sendReloadSignal {
 		require.NotNil(t, m.reloadCh, "Setup: Reload channel should not be nil")
 		m.reloadCh <- struct{}{}
 	}
+}
+
+func createSet(items ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		set[item] = struct{}{}
+	}
+	return set
 }
 
 // run is a helper function which runs the service in a separate goroutine

--- a/server/internal/ingest/ingest_test.go
+++ b/server/internal/ingest/ingest_test.go
@@ -315,7 +315,7 @@ func (m *mockConfigManager) AllowList() []string {
 	return allowListCopy
 }
 
-func (m *mockConfigManager) Allows(name string) bool {
+func (m *mockConfigManager) IsAllowed(name string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	_, ok := m.allowSet[name]

--- a/server/internal/ingest/ingest_test.go
+++ b/server/internal/ingest/ingest_test.go
@@ -308,15 +308,18 @@ func (m *mockConfigManager) Watch(ctx context.Context) (<-chan struct{}, <-chan 
 }
 
 func (m *mockConfigManager) AllowList() []string {
-	m.mu.RLock() // Lock for reading
+	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.allowList
+	allowListCopy := make([]string, len(m.allowList))
+	copy(allowListCopy, m.allowList)
+	return allowListCopy
 }
 
-func (m *mockConfigManager) AllowSet() map[string]struct{} {
-	m.mu.RLock() // Lock for reading
+func (m *mockConfigManager) Allows(name string) bool {
+	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.allowSet
+	_, ok := m.allowSet[name]
+	return ok
 }
 
 func (m *mockConfigManager) setAllowList(t *testing.T, newAllowList []string, sendReloadSignal uint) {

--- a/server/internal/webservice/handlers/handlers_test.go
+++ b/server/internal/webservice/handlers/handlers_test.go
@@ -21,12 +21,17 @@ func (m *mockConfigManager) AllowList() []string {
 	return m.allowedList
 }
 
-func (m *mockConfigManager) AllowSet() map[string]struct{} {
+func (m *mockConfigManager) allowSet() map[string]struct{} {
 	allowSet := make(map[string]struct{}, len(m.allowedList))
 	for _, name := range m.allowedList {
 		allowSet[name] = struct{}{}
 	}
 	return allowSet
+}
+
+func (m *mockConfigManager) Allows(name string) bool {
+	_, ok := m.allowSet()[name]
+	return ok
 }
 
 func runUploadTestCase(

--- a/server/internal/webservice/handlers/handlers_test.go
+++ b/server/internal/webservice/handlers/handlers_test.go
@@ -21,6 +21,14 @@ func (m *mockConfigManager) AllowList() []string {
 	return m.allowedList
 }
 
+func (m *mockConfigManager) AllowSet() map[string]struct{} {
+	allowSet := make(map[string]struct{}, len(m.allowedList))
+	for _, name := range m.allowedList {
+		allowSet[name] = struct{}{}
+	}
+	return allowSet
+}
+
 func runUploadTestCase(
 	t *testing.T,
 	handler http.Handler,

--- a/server/internal/webservice/handlers/handlers_test.go
+++ b/server/internal/webservice/handlers/handlers_test.go
@@ -29,7 +29,7 @@ func (m *mockConfigManager) allowSet() map[string]struct{} {
 	return allowSet
 }
 
-func (m *mockConfigManager) Allows(name string) bool {
+func (m *mockConfigManager) IsAllowed(name string) bool {
 	_, ok := m.allowSet()[name]
 	return ok
 }

--- a/server/internal/webservice/handlers/json_hander.go
+++ b/server/internal/webservice/handlers/json_hander.go
@@ -25,7 +25,7 @@ func (h *jsonHandler) serveHTTP(w http.ResponseWriter, r *http.Request, reqID st
 		return
 	}
 
-	if !h.config.Allows(app) {
+	if !h.config.IsAllowed(app) {
 		http.Error(w, "Invalid application name in URL", http.StatusForbidden)
 		slog.Error("Invalid application name in URL", "req_id", reqID, "app", app)
 		return

--- a/server/internal/webservice/handlers/json_hander.go
+++ b/server/internal/webservice/handlers/json_hander.go
@@ -26,8 +26,7 @@ func (h *jsonHandler) serveHTTP(w http.ResponseWriter, r *http.Request, reqID st
 		return
 	}
 
-	_, allowed := h.config.AllowSet()[app]
-	if !allowed {
+	if !h.config.Allows(app) {
 		http.Error(w, "Invalid application name in URL", http.StatusForbidden)
 		slog.Error("Invalid application name in URL", "req_id", reqID, "app", app)
 		return

--- a/server/internal/webservice/handlers/json_hander.go
+++ b/server/internal/webservice/handlers/json_hander.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"github.com/ubuntu/ubuntu-insights/common/fileutils"
 	"github.com/ubuntu/ubuntu-insights/server/internal/common/config"
@@ -27,7 +26,7 @@ func (h *jsonHandler) serveHTTP(w http.ResponseWriter, r *http.Request, reqID st
 		return
 	}
 
-	allowed := slices.Contains(h.config.AllowList(), app)
+	_, allowed := h.config.AllowSet()[app]
 	if !allowed {
 		http.Error(w, "Invalid application name in URL", http.StatusForbidden)
 		slog.Error("Invalid application name in URL", "req_id", reqID, "app", app)

--- a/server/internal/webservice/handlers/json_hander.go
+++ b/server/internal/webservice/handlers/json_hander.go
@@ -10,11 +10,10 @@ import (
 	"path/filepath"
 
 	"github.com/ubuntu/ubuntu-insights/common/fileutils"
-	"github.com/ubuntu/ubuntu-insights/server/internal/common/config"
 )
 
 type jsonHandler struct {
-	config        config.Provider
+	config        ConfigProvider
 	reportsDir    string
 	maxUploadSize int64
 	successStatus int

--- a/server/internal/webservice/handlers/legacy_upload.go
+++ b/server/internal/webservice/handlers/legacy_upload.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/ubuntu/ubuntu-insights/server/internal/common/config"
 	"github.com/ubuntu/ubuntu-insights/server/internal/common/constants"
 )
 
@@ -23,7 +22,7 @@ type LegacyReport struct {
 }
 
 // NewLegacyReport creates a new LegacyReport handler.
-func NewLegacyReport(cfg config.Provider, reportsDir string, maxUploadSize int64) *LegacyReport {
+func NewLegacyReport(cfg ConfigProvider, reportsDir string, maxUploadSize int64) *LegacyReport {
 	return &LegacyReport{
 		jsonHandler: &jsonHandler{
 			config:        cfg,

--- a/server/internal/webservice/handlers/types.go
+++ b/server/internal/webservice/handlers/types.go
@@ -1,0 +1,6 @@
+package handlers
+
+// ConfigProvider is an interface that defines the configuration access methods used by the handlers.
+type ConfigProvider interface {
+	Allows(string) bool // Allows checks if a given item is allowed based on the present configuration state.
+}

--- a/server/internal/webservice/handlers/types.go
+++ b/server/internal/webservice/handlers/types.go
@@ -2,5 +2,5 @@ package handlers
 
 // ConfigProvider is an interface that defines the configuration access methods used by the handlers.
 type ConfigProvider interface {
-	Allows(string) bool // Allows checks if a given item is allowed based on the present configuration state.
+	IsAllowed(string) bool // IsAllowed checks if a given item is allowed based on the present configuration state.
 }

--- a/server/internal/webservice/handlers/upload.go
+++ b/server/internal/webservice/handlers/upload.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/ubuntu/ubuntu-insights/server/internal/common/config"
 )
 
 // Upload is a handler for uploading standard Ubuntu-Insights JSON reports.
@@ -17,7 +16,7 @@ type Upload struct {
 }
 
 // NewUpload creates a new Upload handler.
-func NewUpload(cfg config.Provider, reportsDir string, maxUploadSize int64) *Upload {
+func NewUpload(cfg ConfigProvider, reportsDir string, maxUploadSize int64) *Upload {
 	return &Upload{
 		jsonHandler: &jsonHandler{
 			config:        cfg,

--- a/server/internal/webservice/webservice.go
+++ b/server/internal/webservice/webservice.go
@@ -45,7 +45,7 @@ type StaticConfig struct {
 type dConfigManager interface {
 	Load() error
 	Watch(context.Context) (<-chan struct{}, <-chan error, error)
-	Allows(string) bool
+	IsAllowed(string) bool
 }
 
 // New creates a new Server instance with the given http.Server and config.ConfigManager.

--- a/server/internal/webservice/webservice.go
+++ b/server/internal/webservice/webservice.go
@@ -46,7 +46,7 @@ type dConfigManager interface {
 	Load() error
 	Watch(context.Context) (<-chan struct{}, <-chan error, error)
 	AllowList() []string
-	AllowSet() map[string]struct{}
+	Allows(string) bool
 }
 
 // New creates a new Server instance with the given http.Server and config.ConfigManager.

--- a/server/internal/webservice/webservice.go
+++ b/server/internal/webservice/webservice.go
@@ -46,6 +46,7 @@ type dConfigManager interface {
 	Load() error
 	Watch(context.Context) (<-chan struct{}, <-chan error, error)
 	AllowList() []string
+	AllowSet() map[string]struct{}
 }
 
 // New creates a new Server instance with the given http.Server and config.ConfigManager.

--- a/server/internal/webservice/webservice.go
+++ b/server/internal/webservice/webservice.go
@@ -45,7 +45,6 @@ type StaticConfig struct {
 type dConfigManager interface {
 	Load() error
 	Watch(context.Context) (<-chan struct{}, <-chan error, error)
-	AllowList() []string
 	Allows(string) bool
 }
 

--- a/server/internal/webservice/webservice_test.go
+++ b/server/internal/webservice/webservice_test.go
@@ -382,12 +382,17 @@ func (t testConfigManager) AllowList() []string {
 	return t.allowList
 }
 
-func (t testConfigManager) AllowSet() map[string]struct{} {
+func (t testConfigManager) allowSet() map[string]struct{} {
 	allowSet := make(map[string]struct{}, len(t.allowList))
 	for _, name := range t.allowList {
 		allowSet[name] = struct{}{}
 	}
 	return allowSet
+}
+
+func (t testConfigManager) Allows(name string) bool {
+	_, ok := t.allowSet()[name]
+	return ok
 }
 
 func newForTest(t *testing.T, cm *testConfigManager, daemonConfig *webservice.StaticConfig) *webservice.Server {

--- a/server/internal/webservice/webservice_test.go
+++ b/server/internal/webservice/webservice_test.go
@@ -382,6 +382,14 @@ func (t testConfigManager) AllowList() []string {
 	return t.allowList
 }
 
+func (t testConfigManager) AllowSet() map[string]struct{} {
+	allowSet := make(map[string]struct{}, len(t.allowList))
+	for _, name := range t.allowList {
+		allowSet[name] = struct{}{}
+	}
+	return allowSet
+}
+
 func newForTest(t *testing.T, cm *testConfigManager, daemonConfig *webservice.StaticConfig) *webservice.Server {
 	t.Helper()
 

--- a/server/internal/webservice/webservice_test.go
+++ b/server/internal/webservice/webservice_test.go
@@ -390,7 +390,7 @@ func (t testConfigManager) allowSet() map[string]struct{} {
 	return allowSet
 }
 
-func (t testConfigManager) Allows(name string) bool {
+func (t testConfigManager) IsAllowed(name string) bool {
 	_, ok := t.allowSet()[name]
 	return ok
 }


### PR DESCRIPTION
This PR modifies the server services to utilize a cached `map[string]struct{}` object to do lookups on the allow list instead of a loop or `slices.Contains` (which is a for loop underneath) . This set-like object is stored within the config manager and set whenever the `allowList` is also set. Consumers access this map by passing in the string they'd like to match within the 'set' to the `Allows` lookup method.

Though the allow list will typically be relatively small, with maybe 20 or so items, at this size it is already faster to utilize a map when trying to check if a structure contains a string (on average the breakpoint is typically around 5 items, though this could be improved with sorting heuristics).

Performance here is more important for the web service since it does a lookup every time it receives an upload request. Over thousands of requests, things add up.

The ingest service was already using a map when syncing workers, so this PR just refactors it slightly to utilize the new allowSet map managed by the config manager.

This PR also includes a small refactor to return copies when using the `AllowList` method in `config` and to move the Provider interface out of `config`, closer to the consumers.