### PR TITLE
feat(insights): Add fixed limits to concurrent report and source processing when uploading

### DIFF
--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -6,6 +6,7 @@ ubuntu-insights (0.3.0) questing; urgency=medium
   * Remove unnecessary dh_dwz override
 
   [ Kat Kuo]
+  * Add fixed limits to concurrent report and source processing when uploading
   * Bump control standards version to 4.7.2
   * Ensure system information collection uses 64-bit memory handling
   * Avoid potential overflow in exponential backoff calculations

--- a/insights/internal/constants/constants.go
+++ b/insights/internal/constants/constants.go
@@ -51,6 +51,12 @@ const (
 
 	// DefaultMinAge is the default value for the uploader's min-age.
 	DefaultMinAge = 604800
+
+	// MaxConcurrentUploadsPerSource is the maximum number of concurrent uploads per source.
+	MaxConcurrentUploadsPerSource = MaxReports
+
+	// MaxConcurrentSources is the maximum number of sources that can be processed concurrently.
+	MaxConcurrentSources = 10
 )
 
 var (

--- a/insights/internal/report/report.go
+++ b/insights/internal/report/report.go
@@ -164,9 +164,11 @@ func GetForPeriod(l *slog.Logger, dir string, t time.Time, period uint32) (Repor
 			return fmt.Errorf("failed to access path: %v", err)
 		}
 
-		// Skip subdirectories.
-		if d.IsDir() && path != dir {
-			return filepath.SkipDir
+		if d.IsDir() {
+			if path != dir {
+				return filepath.SkipDir // Skip subdirectories.
+			}
+			return nil // Continue walking the directory.
 		}
 
 		r, err := New(path)
@@ -205,8 +207,11 @@ func GetAll(l *slog.Logger, dir string) ([]Report, error) {
 			return fmt.Errorf("failed to access path: %v", err)
 		}
 
-		if d.IsDir() && path != dir {
-			return filepath.SkipDir
+		if d.IsDir() {
+			if path != dir {
+				return filepath.SkipDir // Skip subdirectories.
+			}
+			return nil // Continue walking the directory.
 		}
 
 		r, err := New(path)

--- a/insights/internal/uploader/export_test.go
+++ b/insights/internal/uploader/export_test.go
@@ -51,3 +51,17 @@ func WithResponseTimeout(d time.Duration) Options {
 		o.responseTimeout = d
 	}
 }
+
+// WithMaxConcurrentUploadsPerSource sets the maximum number of concurrent uploads per source.
+func WithMaxConcurrentUploadsPerSource(n uint32) Options {
+	return func(o *options) {
+		o.maxConcurrentUploadsPerSource = n
+	}
+}
+
+// WithMaxConcurrentSources sets the maximum number of concurrent sources for the uploader.
+func WithMaxConcurrentSources(n uint32) Options {
+	return func(o *options) {
+		o.maxConcurrentSources = n
+	}
+}

--- a/insights/internal/uploader/testutils/uploader.go
+++ b/insights/internal/uploader/testutils/uploader.go
@@ -20,13 +20,18 @@ type timeProvider interface {
 
 //go:linkname defaultOptions github.com/ubuntu/ubuntu-insights/insights/internal/uploader.defaultOptions
 var defaultOptions struct {
-	baseServerURL   string
-	maxReports      uint32
-	timeProvider    timeProvider
+	baseServerURL string
+	maxReports    uint32
+	timeProvider  timeProvider
+
 	baseRetryPeriod time.Duration
 	maxRetryPeriod  time.Duration
 	maxAttempts     uint32
+
 	responseTimeout time.Duration
+
+	maxConcurrentUploads uint32
+	maxConcurrentSources uint32
 }
 
 // SetServerURL overrides the server url the uploader is using.

--- a/insights/internal/uploader/uploader.go
+++ b/insights/internal/uploader/uploader.go
@@ -39,6 +39,9 @@ type Uploader struct {
 
 	responseTimeout time.Duration // responseTimeout is the timeout for the HTTP request.
 
+	maxConcurrentUploadsPerSource uint32
+	maxConcurrentSources          uint32
+
 	log *slog.Logger
 }
 
@@ -53,6 +56,9 @@ type options struct {
 	maxAttempts     uint32
 
 	responseTimeout time.Duration
+
+	maxConcurrentUploadsPerSource uint32
+	maxConcurrentSources          uint32
 }
 
 var defaultOptions = options{
@@ -66,6 +72,9 @@ var defaultOptions = options{
 	maxAttempts:     15,
 
 	responseTimeout: 10 * time.Second,
+
+	maxConcurrentUploadsPerSource: constants.MaxConcurrentUploadsPerSource,
+	maxConcurrentSources:          constants.MaxConcurrentSources,
 }
 
 // Config represents the uploader specific data needed to upload.
@@ -123,6 +132,9 @@ func New(l *slog.Logger, cm Consent, cachePath string, minAge uint32, dryRun boo
 		maxAttempts:     opts.maxAttempts,
 
 		responseTimeout: opts.responseTimeout,
+
+		maxConcurrentUploadsPerSource: opts.maxConcurrentUploadsPerSource,
+		maxConcurrentSources:          opts.maxConcurrentSources,
 
 		log: l,
 	}, nil


### PR DESCRIPTION
Add fixed limits to concurrent report and source processing when uploading.

Presently, the theoretical infinite number of goroutines can be spawned when the client is processing and uploading reports. Where `r` is the number of reports across all targeted sources and `s` is the number of targeted sources, there is a maximum limit of `r+s`  goroutines that may be spawned, with r routines potentially attempting to send out HTTP requests. 

There is a 150 report limit per source on how many reports are allowed to be on the disk. Typically, a collection call will remove old reports if there are too many already on the disk, limiting the impact of the go routine spawns. But it is possible for abuse to result in a considerable number of sources and reports that the uploader will treat as valid. Should the HTTP requests block or be stuck in retry loops, this can be problematic. 

This PR also includes a test to ensure that the limits are being respected.

There is also a small fix to ensure that the root directory isn't being processed when traversing a directory to search for reports. This change doesn't cause any behavioral changes other than preventing a bit of unnecessary log spam.

---
[UDENG-7470](https://warthogs.atlassian.net/browse/UDENG-7470)

[UDENG-7470]: https://warthogs.atlassian.net/browse/UDENG-7470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ