### PR TITLE
build(insights): Fix build time tests

### DIFF
--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -1,5 +1,11 @@
 ubuntu-insights (0.3.0) questing; urgency=medium
 
+  [ Kat Kuo ]
+  [ Didier Roche-Tolomelli ]
+  * Fix build time tests
+  * Remove unnecessary dh_dwz override
+
+  [ Kat Kuo]
   * Bump control standards version to 4.7.2
   * Ensure system information collection uses 64-bit memory handling
   * Avoid potential overflow in exponential backoff calculations

--- a/insights/debian/rules
+++ b/insights/debian/rules
@@ -5,7 +5,6 @@ export DEB_BUILD_MAINT_OPTIONS = optimize=-lto
 export GOTOOLCHAIN := local
 export INSIGHTS_GO_PACKAGE := $(shell grep-dctrl -s XS-Go-Import-Path -n - ./debian/control)
 export GOFLAGS := -ldflags=-X=$(INSIGHTS_GO_PACKAGE)/internal/constants.Version=$(DEB_VERSION_UPSTREAM) --mod=vendor -buildmode=pie
-export DH_GOLANG_BUILDPKG := github.com/ubuntu/ubuntu-insights/insights/cmd/insights
 export DH_GOLANG_GO_GENERATE := 1
 
 BUILDDIR := _build
@@ -18,6 +17,9 @@ endif
 	dh $@ --builddirectory=$(BUILDDIR) --buildsystem=golang --with=golang
 
 override_dh_auto_install:
+	# Do not ship the library resulting binary cmdline, but we still want it in the package list to run the tests.
+	rm $(BUILDDIR)/bin/C
+	
 	mv $(BUILDDIR)/bin/insights $(BUILDDIR)/bin/ubuntu-insights
 	mv $(BUILDDIR)/src/$(INSIGHTS_GO_PACKAGE)/generated $(CURDIR)/debian/tmp
 	dh_auto_install -- --no-source

--- a/insights/debian/rules
+++ b/insights/debian/rules
@@ -23,6 +23,3 @@ override_dh_auto_install:
 	mv $(BUILDDIR)/bin/insights $(BUILDDIR)/bin/ubuntu-insights
 	mv $(BUILDDIR)/src/$(INSIGHTS_GO_PACKAGE)/generated $(CURDIR)/debian/tmp
 	dh_auto_install -- --no-source
-
-override_dh_dwz:
-	echo "Skipping dwz because the Go compiler already compresses debug symbols."


### PR DESCRIPTION
This PR addresses an issue where only the tests that were present in `insights/cmd/insights` were being run when building the `ubuntu-insights` Debian package. Instead, now all tests are run in a behavior similar to autopkgtest as expected.

There is additional logic to ensure that the C libs aren't being shipped with the package while still allowing for tests to be run for them.

This PR also cleans up and removes the unnecessary `dh_dwz_override` in the `control` file.

The changelog has been updated with new entries to reflect these changes.

---
[UDENG-7468](https://warthogs.atlassian.net/browse/UDENG-7468)


[UDENG-7468]: https://warthogs.atlassian.net/browse/UDENG-7468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ