### PR TITLE
build: Bump control standards version to 4.7.2 and update changelog

### DIFF
--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -1,10 +1,11 @@
-ubuntu-insights (0.3.0~ppa5) questing; urgency=medium
+ubuntu-insights (0.3.0) questing; urgency=medium
 
+  * Bump control standards version to 4.7.2
   * Ensure system information collection uses 64-bit memory handling
   * Avoid potential overflow in exponential backoff calculations
   * Restrict min-age and period inputs to 32-bit values only
 
- -- Kat Kuo <kat.kuo@canonical.com>  Wed, 23 Jul 2025 23:41:43 -0400
+ -- Kat Kuo <kat.kuo@canonical.com>  Thu, 24 Jul 2025 00:11:42 -0400
 
 ubuntu-insights (0.2.2) questing; urgency=medium
 

--- a/insights/debian/control
+++ b/insights/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper-compat (= 13),
                golang-go (>= 2:1.24~) | golang-1.24-go,
                dctrl-tools,
                libwayland-dev,
-Standards-Version: 4.6.2
+Standards-Version: 4.7.2
 Vcs-Browser: https://github.com/ubuntu/ubuntu-insights/tree/main/insights
 Vcs-Git: https://github.com/ubuntu/ubuntu-insights.git
 Homepage: https://github.com/ubuntu/ubuntu-insights


### PR DESCRIPTION
This PR bumps the control standards version to 4.7.2 to silence a lintian info message, and updates the changelog to a state ready for a release to 0.3.0.