### PR TITLE
maint(insights): Sync changelog 0.3.0 with downstream release

### DIFF
--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -5,7 +5,8 @@ ubuntu-insights (0.3.0) questing; urgency=medium
   * Fix build time tests
   * Remove unnecessary dh_dwz override
 
-  [ Kat Kuo]
+  [ Kat Kuo ]
+  * New upstream release (LP: #2118725)
   * Add fixed limits to concurrent report and source processing when uploading
   * Bump control standards version to 4.7.2
   * Ensure system information collection uses 64-bit memory handling


### PR DESCRIPTION
Syncs the changelog for 0.3.0 with the downstream package release.
- Formatting fix
- Reference release launchpad bug

A git tag should be pushed once this PR is merged.