### PR TITLE
feat(insights): Go API defaults to global slogger if one is not passed

### DIFF
--- a/insights/api.go
+++ b/insights/api.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/ubuntu/ubuntu-insights/insights/internal/collector"
 	"github.com/ubuntu/ubuntu-insights/insights/internal/consent"
@@ -41,7 +40,7 @@ type UploadFlags struct {
 //
 // If ConsentDir is not set, a default path will be used.
 // If InsightsDir is not set, a default path will be used.
-// If Logger is not set, a default logger will be created.
+// If Logger is not set, the global default slog Logger will be used.
 func (c Config) Resolve() Config {
 	if c.ConsentDir == "" {
 		c.ConsentDir = constants.DefaultConfigPath
@@ -51,7 +50,7 @@ func (c Config) Resolve() Config {
 	}
 
 	if c.Logger == nil {
-		c.Logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		c.Logger = slog.Default()
 	}
 	return c
 }


### PR DESCRIPTION
This PR changes the Go API behavior to utilize the global slogger instead of a new logger defined and configured internally.

This change is intended to improve the experience for use cases where the caller application is using the global default slogger, possibly modifying this logger. By defaulting to this slogger, the caller no longer needs to pass it if they are using it. If they are not using it, the old internal logger matches what the default logger would have been, so there is no behavior change there.

It is important to note that we don't make changes internally to the default slogger other than in parts of the CLI implementation, meaning we don't interfere with the Go API consumer's default slogger.