### PR TITLE
ci(qa-deb): Change trigger conditions

### DIFF
--- a/.github/workflows/qa-debian.yaml
+++ b/.github/workflows/qa-debian.yaml
@@ -3,13 +3,14 @@ name: Debian package tests
 
 on:
   pull_request:
-    paths-ignore:
-      - server/**
-      - tools/**
-      - "*.md"
+    paths:
+      - "insights/**"
+      - ".github/workflows/qa-debian.yaml"
+      - "!**.md"
   workflow_dispatch:
   push:
     branches: [main]
+    tags: ["*"]
 
 env:
   UBUNTU_VERSIONS: |
@@ -26,6 +27,41 @@ jobs:
       autopkgtest-host: ${{ env.AUTOPKGTEST_HOST }}
     steps:
       - run: "true"
+
+  check-modified-files:
+    name: Check modified files
+    runs-on: ubuntu-latest
+    outputs:
+      list: ${{ fromJSON(steps.git-diff.outputs.modified_files) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+
+      - id: git-diff
+        name: Check modified files
+        run: |
+          set -ue
+
+          base_ref=${{ github.event.pull_request.base.sha }}
+          if [ -z "${base_ref}" ]; then
+            base_ref=${{ github.event.before }}
+          fi
+          if [ -z "${base_ref}" ]; then
+            base_ref=$(git log --root --reverse -n1 --format=%H)
+          fi
+
+          # Build a JSON array of modified paths.
+          modified_files=$(git diff --name-only "${base_ref}" HEAD | \
+            while IFS= read -r line; do
+              jq -n --arg path "$line" '$path'
+            done | jq -n '. |= [inputs]')
+          echo "${modified_files}"
+
+          escaped_json=$(echo "${modified_files}" | jq '.| tostring')
+          echo "modified_files=${escaped_json}" >> "${GITHUB_OUTPUT}"
 
   build-ubuntu-insights:
     name: Build ubuntu-insights debian package
@@ -112,6 +148,20 @@ jobs:
     needs:
       - plan
       - build-ubuntu-insights
+      - check-modified-files
+
+    # Run autopkgtest only on:
+    # - Push events to main branch
+    # - When a file in the insights/debian/ directory is modified
+    # - When this file is modified
+    # - When a tag is pushed
+    # - When a release is created
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      contains(needs.check-modified-files.outputs.list, 'insights/debian/') ||
+      contains(needs.check-modified-files.outputs.list, '.github/workflows/qa-debian.yaml') ||
+      startsWith(github.ref, 'refs/tags/') ||
+      github.event_name == 'release' }}
+
     steps:
       # Copied from https://github.com/ubuntu/authd/blob/main/.github/workflows/build-deb.yaml
       # FIXME: Use dynamic outputs when possible: https://github.com/actions/runner/pull/2477

--- a/.github/workflows/qa-debian.yaml
+++ b/.github/workflows/qa-debian.yaml
@@ -31,37 +31,36 @@ jobs:
   check-modified-files:
     name: Check modified files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       list: ${{ fromJSON(steps.git-diff.outputs.modified_files) }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 100
 
       - id: git-diff
         name: Check modified files
         run: |
           set -ue
 
-          base_ref=${{ github.event.pull_request.base.sha }}
-          if [ -z "${base_ref}" ]; then
-            base_ref=${{ github.event.before }}
-          fi
-          if [ -z "${base_ref}" ]; then
-            base_ref=$(git log --root --reverse -n1 --format=%H)
+          # Default to empty array
+          modified_files='[]'
+
+          # For pull requests, use gh pr diff to get the list of modified files
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            modified_files=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | \
+              while IFS= read -r line; do
+                jq -n --arg path "$line" '$path'
+              done | jq -n '. |= [inputs]')
           fi
 
-          # Build a JSON array of modified paths.
-          modified_files=$(git diff --name-only "${base_ref}" HEAD | \
-            while IFS= read -r line; do
-              jq -n --arg path "$line" '$path'
-            done | jq -n '. |= [inputs]')
           echo "${modified_files}"
-
           escaped_json=$(echo "${modified_files}" | jq '.| tostring')
           echo "modified_files=${escaped_json}" >> "${GITHUB_OUTPUT}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
   build-ubuntu-insights:
     name: Build ubuntu-insights debian package


### PR DESCRIPTION
This PR modifies the trigger conditions of the qa-deb workflow, including adding a supporting job to get the diff.

The `Check modified files` job was copied from the Authd repository with some changes to support our needs.

This workflow now uses mostly an allow method when triggering on pull request events to be more specific.
 - Anything in the `insights/` directory
 - This workflow `.github/workflows/qa-debian.yaml`
 - Excluding markdown file only changes
 
 Using the new `Check modified files` job, autopkgtests now only run with the following additional triggers:
 - Push events to main branch
 - When a file in the insights/debian/ directory is modified
 - When this file is modified
 - When a tag is pushed
 - When a release is created
 
This was done as this job can add a good amount of extra time, and it is mostly just running the standard Go tests anyway. Changes to the `insights/debian/` directory can cause how and what the trigger is for, so we want to run autopkgtest in this case.

---
[UDENG-7384](https://warthogs.atlassian.net/browse/UDENG-7384)

[UDENG-7384]: https://warthogs.atlassian.net/browse/UDENG-7384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ