### PR TITLE
maint: Pin ubuntu-insights/common dependency to v0.3.0

### DIFF
--- a/insights/go.mod
+++ b/insights/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19
-	github.com/ubuntu/ubuntu-insights/common v0.0.0-20250627183928-38f4a1b709cd
+	github.com/ubuntu/ubuntu-insights/common v0.3.0
 	golang.org/x/text v0.27.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/insights/go.sum
+++ b/insights/go.sum
@@ -54,8 +54,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 h1:IP8p46//e//o0KPZdAzl+WF1DdRKHXfkbB+sQDCAlkw=
 github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/ubuntu-insights/common v0.0.0-20250627183928-38f4a1b709cd h1:QDn3zyf+qXVgz9uDrwkyJmeBM2g3IxqGTXW44E8FDH8=
-github.com/ubuntu/ubuntu-insights/common v0.0.0-20250627183928-38f4a1b709cd/go.mod h1:Xyi34TiWUpW1T8BL9BRvWITGm9pXf2Aw+Okwc5UdOjs=
+github.com/ubuntu/ubuntu-insights/common v0.3.0 h1:ybVzo24GGzveOHQT9OoO1lKU006UgETfhm38LzJJwFo=
+github.com/ubuntu/ubuntu-insights/common v0.3.0/go.mod h1:Xyi34TiWUpW1T8BL9BRvWITGm9pXf2Aw+Okwc5UdOjs=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/server/go.mod
+++ b/server/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.38.0
-	github.com/ubuntu/ubuntu-insights/common v0.0.0-20250627183928-38f4a1b709cd
+	github.com/ubuntu/ubuntu-insights/common v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/server/go.sum
+++ b/server/go.sum
@@ -265,8 +265,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
-github.com/ubuntu/ubuntu-insights/common v0.0.0-20250627183928-38f4a1b709cd h1:QDn3zyf+qXVgz9uDrwkyJmeBM2g3IxqGTXW44E8FDH8=
-github.com/ubuntu/ubuntu-insights/common v0.0.0-20250627183928-38f4a1b709cd/go.mod h1:Xyi34TiWUpW1T8BL9BRvWITGm9pXf2Aw+Okwc5UdOjs=
+github.com/ubuntu/ubuntu-insights/common v0.3.0 h1:ybVzo24GGzveOHQT9OoO1lKU006UgETfhm38LzJJwFo=
+github.com/ubuntu/ubuntu-insights/common v0.3.0/go.mod h1:Xyi34TiWUpW1T8BL9BRvWITGm9pXf2Aw+Okwc5UdOjs=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=


### PR DESCRIPTION
This PR pins the `ubuntu-insights/common` dependency for the `insights` and `server` modules to `v0.3.0` following the creation of the `common/v0.3.0` tag. This makes this more parsable and helps with dependency management should these two modules be imported elsewhere.