### PR TITLE
feat(insights): Expose typed errors in the Go API

### DIFF
--- a/insights/api.go
+++ b/insights/api.go
@@ -36,6 +36,22 @@ type UploadFlags struct {
 	DryRun bool
 }
 
+// Collect errors.
+var (
+	// ErrDuplicateReport is returned by Collect when a report for the specified period already exists.
+	ErrDuplicateReport = collector.ErrDuplicateReport
+	// ErrSanitizeError is returned by Collect when the Config is not properly configured in an unrecoverable manner.
+	ErrSanitizeError = collector.ErrSanitizeError
+	// ErrSourceMetricsError is returned by Collect when the source metrics could not be loaded or parsed.
+	ErrSourceMetricsError = collector.ErrSourceMetricsError
+)
+
+// Upload errors.
+var (
+	// ErrSendFailure is returned by Upload when a report fails to be sent to the server, either due to a network error or a non-200 status code.
+	ErrSendFailure = uploader.ErrSendFailure
+)
+
 // Resolve returns a copy of the config with default values filled in where necessary.
 //
 // If ConsentDir is not set, a default path will be used.
@@ -86,7 +102,7 @@ func (c Config) Collect(source string, flags CollectFlags) ([]byte, error) {
 	}
 
 	insights, err := col.Compile(flags.Force)
-	if err != nil {
+	if err != nil { // Errors may need to be exposed for caller correction.
 		return nil, err
 	}
 

--- a/insights/internal/collector/collector.go
+++ b/insights/internal/collector/collector.go
@@ -23,6 +23,8 @@ var (
 	ErrDuplicateReport = fmt.Errorf("report already exists for this period")
 	// ErrSanitizeError is returned when the Config is not properly configured in an unrecoverable manner.
 	ErrSanitizeError = fmt.Errorf("collect is not properly configured")
+	// ErrSourceMetricsError is returned when the source metrics could not be loaded or parsed.
+	ErrSourceMetricsError = fmt.Errorf("source metrics could not be loaded or parsed")
 )
 
 // Insights contains the insights report compiled by the collector.
@@ -206,7 +208,7 @@ func (c collector) Compile(force bool) (insights Insights, err error) {
 
 	insights, err = c.compile()
 	if err != nil {
-		return Insights{}, fmt.Errorf("failed to compile insights: %v", err)
+		return Insights{}, fmt.Errorf("failed to compile insights: %w", err) // Need to expose these errors
 	}
 	c.log.Info("Insights report compiled", "report", insights)
 
@@ -300,7 +302,7 @@ func (c collector) compile() (Insights, error) {
 	// Load source specific metrics.
 	metrics, err := c.getSourceMetrics()
 	if err != nil {
-		return Insights{}, fmt.Errorf("failed to load source metrics: %v", err)
+		return Insights{}, errors.Join(ErrSourceMetricsError, err)
 	}
 	insights.SourceMetrics = metrics
 

--- a/insights/internal/uploader/upload.go
+++ b/insights/internal/uploader/upload.go
@@ -203,11 +203,11 @@ func (um Uploader) upload(r report.Report, uploadedDir, url string, consent, for
 	if err != nil {
 		return fmt.Errorf("failed to mark report as processed: %v", err)
 	}
-	if err := um.send(url, data); err != nil {
-		if _, err := r.UndoProcessed(); err != nil {
-			return fmt.Errorf("failed to send data: %v, and failed to restore the original report: %v", err, err)
+	if sendErr := um.send(url, data); sendErr != nil {
+		if _, undoErr := r.UndoProcessed(); undoErr != nil { // Need to expose sendErr.
+			return errors.Join(sendErr, fmt.Errorf("failed to restore the original report: %v", undoErr))
 		}
-		return fmt.Errorf("failed to send data: %w", err)
+		return sendErr
 	}
 
 	return nil


### PR DESCRIPTION
This PR ensures that certain typed errors are exposed in the Go API. This is to allow for API callers to react to these errors more precisely and easily.