### PR TITLE
deps: Bump toolchain to 1.24.6

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.24.0
 
-toolchain go1.24.4
+toolchain go1.24.6
 
 use (
 	./common


### PR DESCRIPTION
Bumps toolchain to 1.24.6 to resolve `GO-2025-3849` which is present in the server module.