### PR TITLE
maint(server): Rename ubuntu_desktop_provision to more generic ubuntu_desktop_installer

### DIFF
--- a/server/cmd/ingest-service/daemon/testdata/TestMigrateRequiresDirArgument/golden/basic_migration
+++ b/server/cmd/ingest-service/daemon/testdata/TestMigrateRequiresDirArgument/golden/basic_migration
@@ -4,4 +4,4 @@
 - darwin
 - ubuntu_report
 - schema_migrations
-- ubuntu_desktop_provision
+- ubuntu_desktop_installer

--- a/server/cmd/ingest-service/daemon/testdata/TestMigrateRequiresDirArgument/golden/pre-applied_migrations
+++ b/server/cmd/ingest-service/daemon/testdata/TestMigrateRequiresDirArgument/golden/pre-applied_migrations
@@ -4,4 +4,4 @@
 - darwin
 - ubuntu_report
 - schema_migrations
-- ubuntu_desktop_provision
+- ubuntu_desktop_installer

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/all_valid_apps
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/all_valid_apps
@@ -11,7 +11,7 @@
       "OptOutReports": 2,
       "OptInReports": 5
     },
-    "ubuntu_desktop_provision": {
+    "ubuntu_desktop_installer": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/legacy_ubuntu_report_apps
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/legacy_ubuntu_report_apps
@@ -21,7 +21,7 @@
       "OptOutReports": 0,
       "OptInReports": 0
     },
-    "ubuntu_desktop_provision": {
+    "ubuntu_desktop_installer": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/new_reports_only
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/new_reports_only
@@ -11,7 +11,7 @@
       "OptOutReports": 2,
       "OptInReports": 5
     },
-    "ubuntu_desktop_provision": {
+    "ubuntu_desktop_installer": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/only_linux_valid
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/only_linux_valid
@@ -22,7 +22,7 @@
       "OptOutReports": 7,
       "OptInReports": 5
     },
-    "ubuntu_desktop_provision": {
+    "ubuntu_desktop_installer": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/preexisting_and_new_reports
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/preexisting_and_new_reports
@@ -11,7 +11,7 @@
       "OptOutReports": 7,
       "OptInReports": 10
     },
-    "ubuntu_desktop_provision": {
+    "ubuntu_desktop_installer": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/preexisting_reports_only
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/preexisting_reports_only
@@ -11,7 +11,7 @@
       "OptOutReports": 2,
       "OptInReports": 5
     },
-    "ubuntu_desktop_provision": {
+    "ubuntu_desktop_installer": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_invalid_json
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_invalid_json
@@ -11,7 +11,7 @@
       "OptOutReports": 0,
       "OptInReports": 1
     },
-    "ubuntu_desktop_provision": {
+    "ubuntu_desktop_installer": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_unexpected_fields
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_unexpected_fields
@@ -11,7 +11,7 @@
       "OptOutReports": 0,
       "OptInReports": 3
     },
-    "ubuntu_desktop_provision": {
+    "ubuntu_desktop_installer": {
       "TotalReports": 0,
       "OptOutReports": 0,
       "OptInReports": 0

--- a/server/cmd/ingest-service/integration-tests/testdata/TestMigrate/golden/basic_migration
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestMigrate/golden/basic_migration
@@ -4,4 +4,4 @@
 - darwin
 - ubuntu_report
 - schema_migrations
-- ubuntu_desktop_provision
+- ubuntu_desktop_installer

--- a/server/cmd/ingest-service/integration-tests/testdata/TestMigrate/golden/pre-applied_migrations
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestMigrate/golden/pre-applied_migrations
@@ -4,4 +4,4 @@
 - darwin
 - ubuntu_report
 - schema_migrations
-- ubuntu_desktop_provision
+- ubuntu_desktop_installer

--- a/server/migrations/000007_rename-ubuntu_desktop_installer-to-provision.down.sql
+++ b/server/migrations/000007_rename-ubuntu_desktop_installer-to-provision.down.sql
@@ -1,0 +1,11 @@
+-- Revert table name
+ALTER TABLE ubuntu_desktop_installer RENAME TO ubuntu_desktop_provision;
+
+-- Revert index names
+ALTER INDEX idx_ubuntu_desktop_installer_report_id RENAME TO idx_ubuntu_desktop_provision_report_id;
+ALTER INDEX idx_ubuntu_desktop_installer_entry_time_optout RENAME TO idx_ubuntu_desktop_provision_entry_time_optout;
+ALTER INDEX idx_ubuntu_desktop_installer_collection_time RENAME TO idx_ubuntu_desktop_provision_collection_time;
+ALTER INDEX idx_ubuntu_desktop_installer_hardware RENAME TO idx_ubuntu_desktop_provision_hardware;
+ALTER INDEX idx_ubuntu_desktop_installer_software RENAME TO idx_ubuntu_desktop_provision_software;
+ALTER INDEX idx_ubuntu_desktop_installer_platform RENAME TO idx_ubuntu_desktop_provision_platform;
+ALTER INDEX idx_ubuntu_desktop_installer_source_metrics RENAME TO idx_ubuntu_desktop_provision_source_metrics;

--- a/server/migrations/000007_rename-ubuntu_desktop_provision-to-installer.up.sql
+++ b/server/migrations/000007_rename-ubuntu_desktop_provision-to-installer.up.sql
@@ -1,0 +1,11 @@
+-- Rename table
+ALTER TABLE ubuntu_desktop_provision RENAME TO ubuntu_desktop_installer;
+
+-- Rename indexes
+ALTER INDEX idx_ubuntu_desktop_provision_report_id RENAME TO idx_ubuntu_desktop_installer_report_id;
+ALTER INDEX idx_ubuntu_desktop_provision_entry_time_optout RENAME TO idx_ubuntu_desktop_installer_entry_time_optout;
+ALTER INDEX idx_ubuntu_desktop_provision_collection_time RENAME TO idx_ubuntu_desktop_installer_collection_time;
+ALTER INDEX idx_ubuntu_desktop_provision_hardware RENAME TO idx_ubuntu_desktop_installer_hardware;
+ALTER INDEX idx_ubuntu_desktop_provision_software RENAME TO idx_ubuntu_desktop_installer_software;
+ALTER INDEX idx_ubuntu_desktop_provision_platform RENAME TO idx_ubuntu_desktop_installer_platform;
+ALTER INDEX idx_ubuntu_desktop_provision_source_metrics RENAME TO idx_ubuntu_desktop_installer_source_metrics;


### PR DESCRIPTION
Rename `ubuntu_desktop_provision` to the more generic `ubuntu_desktop_installer`. Since there are published charm revisions, this is done in a new migration file instead of modifying the existing one. 