### PR TITLE
refactor(insights): rename functions and types for consistency in C API

### DIFF
--- a/insights/C/types.h
+++ b/insights/C/types.h
@@ -6,40 +6,42 @@
 #include <stdint.h>
 
 typedef enum {
-  CONSENT_UNKNOWN = -1,
-  CONSENT_FALSE = 0,
-  CONSENT_TRUE = 1,
-} ConsentState;
+  INSIGHTS_CONSENT_UNKNOWN = -1,
+  INSIGHTS_CONSENT_FALSE = 0,
+  INSIGHTS_CONSENT_TRUE = 1,
+} insights_consent_state;
 
 typedef struct {
-  const char *consentDir;  // default: "${os.UserConfigDir}/ubuntu-insights"
-  const char *insightsDir; // default: "${os.UserCacheDir}/ubuntu-insights"
-  bool verbose;            // Debug if true, info otherwise (default: false)
-} InsightsConfig;
+  const char *consent_dir;  // default: "${os.UserConfigDir}/ubuntu-insights"
+  const char *insights_dir; // default: "${os.UserCacheDir}/ubuntu-insights"
+  bool verbose;             // Debug if true, info otherwise (default: false)
+} insights_config;
 
 /**
  * @brief Parameters for insights collection.
  *
- * @note sourceMetricsPath and sourceMetricsJSON are mutually exclusive.
+ * @note source_metrics_path and source_metrics_json are mutually exclusive.
  */
 typedef struct {
-  const char *sourceMetricsPath; // Path to JSON file (default: empty)
-  const void *sourceMetricsJSON; // Raw JSON data as bytes (default: NULL)
-  size_t sourceMetricsJSONLen;   // Length of sourceMetricsJSON in bytes
-  uint32_t period;               // Collection period in seconds (default: 0)
-  bool force;  // Force collection, ignoring duplicates (default: false)
-  bool dryRun; // Simulate operation without writing files (default: false)
-} CollectFlags;
+  const char *source_metrics_path; // Path to JSON file (default: empty)
+  const void *source_metrics_json; // Raw JSON data as bytes (default: NULL)
+  size_t source_metrics_json_len;  // Length of source_metrics_json in bytes
+  uint32_t period;                 // Collection period in seconds (default: 0)
+  bool force;   // Force collection, ignoring duplicates (default: false)
+  bool dry_run; // Simulate operation without writing files (default: false)
+} insights_collect_flags;
 
 typedef struct {
-  uint32_t minAge;    // default: 1
-  bool force, dryRun; // default: false
-} UploadFlags;
+  uint32_t min_age; // default: 1
+  bool force;
+  bool dry_run; // default: false
+} insights_upload_flags;
 
-// typedefs to be able to have `const` in Go.
-typedef const char Cchar;
-typedef const InsightsConfig CInsightsConfig;
-typedef const CollectFlags CCollectFlags;
-typedef const UploadFlags CUploadFlags;
+// Typedefs to be able to have `const` in Go (GNU style lowercase with
+// underscores).
+typedef const char insights_const_char;
+typedef const insights_config insights_const_config;
+typedef const insights_collect_flags insights_const_collect_flags;
+typedef const insights_upload_flags insights_const_upload_flags;
 
 #endif // INSIGHTS_TYPES_H

--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -1,7 +1,8 @@
-ubuntu-insights (0.5.1) questing; urgency=medium
+ubuntu-insights (0.6.0) questing; urgency=medium
 
   * New upstream release (LP: #2120272)
   * libinsights: Fix types.h references
+  * libinsights: (Breaking) Rename C bindings method and type definitions
 
  -- Kat Kuo <kat.kuo@canonical.com>  Sun, 10 Aug 2025 23:49:25 -0400
 

--- a/insights/debian/libinsights0.symbols
+++ b/insights/debian/libinsights0.symbols
@@ -1,9 +1,7 @@
 libinsights.so.0 libinsights0 #MINVER#
 * Build-Depends-Package: libinsights-dev
  cleanup@Base 0.5.0
- collectInsights@Base 0.5.0
  fatalf@Base 0.5.0
- getConsentState@Base 0.5.0
  get_displays@Base 0.5.0
  get_output_count@Base 0.5.0
  global_handler@Base 0.5.0
@@ -12,9 +10,11 @@ libinsights.so.0 libinsights0 #MINVER#
  handle_geometry@Base 0.5.0
  handle_mode@Base 0.5.0
  init_wayland@Base 0.5.0
- setConsentState@Base 0.5.0
+ insights_collect@Base 0.6.0
+ insights_get_consent_state@Base 0.6.0
+ insights_set_consent_state@Base 0.6.0
+ insights_upload@Base 0.6.0
  set_displays@Base 0.5.0
  set_memory_error@Base 0.5.0
- uploadInsights@Base 0.5.0
  (regex|optional).*crosscall.* 0.5.0
  (regex|optional)"_cgo.*" 0.5.0


### PR DESCRIPTION
This PR renames the C bindings functions and types for consistency and to improve idiomatic-ness. It also puts into use the previous unused custom const char type (named `Cchar` before, now `CInsightsChar`) in order for the generated headers to use constant char types where appropriate. 

Since the bindings might be used in a variety of situations, we are just following GNU conventions here https://www.gnu.org/prep/standards/html_node/Names.html. 