### PR TITLE
fix(insights): Clean up generated sources in prepare-source.sh

### DIFF
--- a/insights/debian/prepare-source.sh
+++ b/insights/debian/prepare-source.sh
@@ -7,6 +7,9 @@ is_source_build=$(git status > /dev/null 2>&1 && echo "1" || true)
 
 # Handle vendoring
 if [ -n "${is_source_build}" ]; then
+    # Ensure sources are clean
+    rm -r generated &> /dev/null || true
+    # Handle vendoring
     rm -r vendor &> /dev/null || true
     go mod vendor
 fi


### PR DESCRIPTION
Previously, if `go generate` was ran locally, it wouldn't get cleaned before packaging. Especially since that folder is included in `.gitignore`, it was easy to overlook this and actually create deb package sources that include the `generated` folder. This is especially an issue if the C bindings shared libs were generated.

This PR simply ensures that this folder is removed.