### PR TITLE
fix(insights): Update collect dry run behavior to only warn if consent file is missing

### DIFF
--- a/insights/api.go
+++ b/insights/api.go
@@ -3,6 +3,7 @@ package insights
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -44,6 +45,12 @@ var (
 	ErrSanitizeError = collector.ErrSanitizeError
 	// ErrSourceMetricsError is returned by Collect when the source metrics could not be loaded or parsed.
 	ErrSourceMetricsError = collector.ErrSourceMetricsError
+)
+
+// Consent errors.
+var (
+	// ErrConsentFileNotFound is returned by Consent when the consent file is not found.
+	ErrConsentFileNotFound = consent.ErrConsentFileNotFound
 )
 
 // Upload errors.
@@ -107,7 +114,9 @@ func (c Config) Collect(source string, flags CollectFlags) ([]byte, error) {
 	}
 
 	if err := col.Write(insights, flags.DryRun); err != nil {
-		return nil, err
+		if !(flags.DryRun && errors.Is(err, ErrConsentFileNotFound)) {
+			return nil, err
+		}
 	}
 
 	return json.MarshalIndent(insights, "", "  ")

--- a/insights/api_test.go
+++ b/insights/api_test.go
@@ -84,16 +84,14 @@ func TestCollect(t *testing.T) {
 				DryRun: true,
 			},
 		},
-
-		// Error cases
-		"Missing consent file errors": {
+		"Missing consent file does not error in dry run": {
 			source: "missing_consent_file",
 			collectFlags: insights.CollectFlags{
 				DryRun: true,
 			},
-
-			wantErr: true,
 		},
+
+		// Error cases
 		"Invalid source metrics JSON errors": {
 			source: "valid_true",
 			collectFlags: insights.CollectFlags{

--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -3,6 +3,7 @@ ubuntu-insights (0.6.0) questing; urgency=medium
   * New upstream release (LP: #2120272)
   * libinsights: Fix types.h references
   * libinsights: (Breaking) Rename C bindings method and type definitions
+  * libinsights: Dry run collect only warns if consent file is missing
 
  -- Kat Kuo <kat.kuo@canonical.com>  Sun, 10 Aug 2025 23:49:25 -0400
 


### PR DESCRIPTION
This PR updates the collect dry run behavior to only warn if the consent file is missing. This differs slightly from the CMD behavior in that this check only happens for dry runs of collect. If the collection attempt is not a dry run, then the error is still passed on.

This change is to better facilitate the init processes such that we would like to get an example/first report even if Ubuntu Insights hasn't been set up and there has been no consent interaction. 

For users that need functionality to see if consent has been interacted with, they should use the get consent methods and check for error returns there.