### PR TITLE
feat(insights): Expose collector write method

### DIFF
--- a/insights/C/libinsights.go
+++ b/insights/C/libinsights.go
@@ -110,6 +110,7 @@ func writeCustomInsights(config *C.insights_const_config, source *C.insights_con
 	f := insights.WriteFlags{}
 	if flags != nil {
 		f.Period = (uint32)(flags.period)
+		f.Force = (bool)(flags.force)
 		f.DryRun = (bool)(flags.dry_run)
 	}
 

--- a/insights/C/libinsights_test.go
+++ b/insights/C/libinsights_test.go
@@ -12,6 +12,11 @@ func TestCollect(t *testing.T) {
 	main.TestCollectImpl(t)
 }
 
+// TestWrite tests C.WriteInsights.
+func TestWrite(t *testing.T) {
+	main.TestWriteImpl(t)
+}
+
 // TestUpload tests C.UploadInsights.
 func TestUpload(t *testing.T) {
 	main.TestUploadImpl(t)

--- a/insights/C/libinsightstest.go
+++ b/insights/C/libinsightstest.go
@@ -210,6 +210,7 @@ func TestWriteImpl(t *testing.T) {
 			report: "report data",
 			flags: &C.insights_write_flags{
 				period:  C.uint32_t(10),
+				force:   C.bool(true),
 				dry_run: C.bool(true),
 			},
 		},

--- a/insights/C/testdata/TestWrite/golden/empty_case
+++ b/insights/C/testdata/TestWrite/golden/empty_case
@@ -1,0 +1,9 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+source: ""
+report: ""
+flags:
+    period: 0
+    dryrun: false

--- a/insights/C/testdata/TestWrite/golden/empty_case
+++ b/insights/C/testdata/TestWrite/golden/empty_case
@@ -6,4 +6,5 @@ source: ""
 report: ""
 flags:
     period: 0
+    force: false
     dryrun: false

--- a/insights/C/testdata/TestWrite/golden/error_is_returned
+++ b/insights/C/testdata/TestWrite/golden/error_is_returned
@@ -1,0 +1,9 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+source: ""
+report: ""
+flags:
+    period: 0
+    dryrun: false

--- a/insights/C/testdata/TestWrite/golden/error_is_returned
+++ b/insights/C/testdata/TestWrite/golden/error_is_returned
@@ -6,4 +6,5 @@ source: ""
 report: ""
 flags:
     period: 0
+    force: false
     dryrun: false

--- a/insights/C/testdata/TestWrite/golden/parameters_are_passed
+++ b/insights/C/testdata/TestWrite/golden/parameters_are_passed
@@ -1,0 +1,9 @@
+conf:
+    consentdir: home/etc/dir
+    insightsdir: insights/dir
+    logger: null
+source: platform
+report: report data
+flags:
+    period: 10
+    dryrun: true

--- a/insights/C/testdata/TestWrite/golden/parameters_are_passed
+++ b/insights/C/testdata/TestWrite/golden/parameters_are_passed
@@ -6,4 +6,5 @@ source: platform
 report: report data
 flags:
     period: 10
+    force: true
     dryrun: true

--- a/insights/C/types.h
+++ b/insights/C/types.h
@@ -32,6 +32,11 @@ typedef struct {
 } insights_collect_flags;
 
 typedef struct {
+  uint32_t period; // Collection period in seconds (default: 0)
+  bool dry_run;    // Simulate operation without writing files (default: false)
+} insights_write_flags;
+
+typedef struct {
   uint32_t min_age; // default: 1
   bool force;
   bool dry_run; // default: false
@@ -42,6 +47,7 @@ typedef struct {
 typedef const char insights_const_char;
 typedef const insights_config insights_const_config;
 typedef const insights_collect_flags insights_const_collect_flags;
+typedef const insights_write_flags insights_const_write_flags;
 typedef const insights_upload_flags insights_const_upload_flags;
 
 #endif // INSIGHTS_TYPES_H

--- a/insights/C/types.h
+++ b/insights/C/types.h
@@ -33,6 +33,7 @@ typedef struct {
 
 typedef struct {
   uint32_t period; // Collection period in seconds (default: 0)
+  bool force;      // Force write, ignoring duplicates (default: false)
   bool dry_run;    // Simulate operation without writing files (default: false)
 } insights_write_flags;
 

--- a/insights/api_test.go
+++ b/insights/api_test.go
@@ -155,12 +155,8 @@ func TestCollect(t *testing.T) {
 			}
 
 			// test that dry run was applied.
-			f, err := os.Open(filepath.Join(dir, tc.source, "local"))
-			require.NoError(t, err, "Setup: failed to open temp directory")
-			defer f.Close()
-
-			_, err = f.Readdir(1)
-			assert.ErrorIs(t, err, io.EOF)
+			assert.NoDirExists(t, filepath.Join(dir, tc.source, "local"))
+			assert.NoDirExists(t, filepath.Join(dir, tc.source, "uploaded"))
 		})
 	}
 }
@@ -221,6 +217,7 @@ func TestWrite(t *testing.T) {
 
 			// test that dry run was applied.
 			assert.NoDirExists(t, filepath.Join(dir, tc.source, "local"))
+			assert.NoDirExists(t, filepath.Join(dir, tc.source, "uploaded"))
 		})
 	}
 }

--- a/insights/api_test.go
+++ b/insights/api_test.go
@@ -165,6 +165,66 @@ func TestCollect(t *testing.T) {
 	}
 }
 
+func TestWrite(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		source string
+		report []byte
+
+		wantErr bool
+	}{
+		"Valid source and empty insights doesn't error": {
+			source: "valid_true",
+			report: []byte(`{}`),
+		},
+		"Valid source and insights doesn't error": {
+			source: "valid_true",
+			report: []byte(`{"insightsVersion": "1.0.0", "sourceMetrics": {"inner": "value"}}`),
+		},
+
+		// Error cases
+		"Invalid source errors": {
+			source:  "invalid",
+			report:  []byte(`{}`),
+			wantErr: true,
+		},
+		"Nil insights errors": {
+			source:  "valid_true",
+			report:  nil,
+			wantErr: true,
+		},
+		"Unexpect insights fields errors": {
+			source:  "valid_true",
+			report:  []byte(`{"insightsVersion": "1.0.0", "sourceMetrics": {"inner": "value"}, "unexpectedField": "value"}`),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			conf := insights.Config{
+				ConsentDir:  filepath.Join("testdata", "consent_files"),
+				InsightsDir: dir,
+			}
+
+			err := conf.Write(tc.source, tc.report, insights.WriteFlags{DryRun: true})
+			if tc.wantErr {
+				require.Error(t, err, "Expected error from write but got none")
+				return
+			}
+			require.NoError(t, err, "Got unexpected error from write")
+
+			// test that dry run was applied.
+			assert.NoDirExists(t, filepath.Join(dir, tc.source, "local"))
+		})
+	}
+}
+
 // TestUpload tests the Upload insights.
 func TestUpload(t *testing.T) {
 	t.Parallel()

--- a/insights/cmd/insights/commands/collect.go
+++ b/insights/cmd/insights/commands/collect.go
@@ -71,7 +71,6 @@ func (a App) collectRun() (err error) {
 
 	cConfig := collector.Config{
 		Source:            a.config.Collect.Source,
-		Period:            a.config.Collect.Period,
 		CachePath:         a.config.insightsDir,
 		SourceMetricsPath: a.config.Collect.SourceMetricsPath,
 	}
@@ -86,7 +85,7 @@ func (a App) collectRun() (err error) {
 		return err
 	}
 
-	insights, err := c.Compile(a.config.Collect.Force)
+	insights, err := c.Compile()
 	if err != nil {
 		return err
 	}
@@ -97,7 +96,7 @@ func (a App) collectRun() (err error) {
 	}
 	fmt.Println(string(ib))
 
-	err = c.Write(insights, a.config.Collect.DryRun)
+	err = c.Write(insights, a.config.Collect.Period, a.config.Collect.Force, a.config.Collect.DryRun)
 	if errors.Is(err, consent.ErrConsentFileNotFound) {
 		slog.Warn("Consent file not found, will not write insights report to disk or upload.")
 		return nil

--- a/insights/cmd/insights/commands/collect_test.go
+++ b/insights/cmd/insights/commands/collect_test.go
@@ -137,7 +137,7 @@ func TestCollect(t *testing.T) {
 				DryRun bool
 			}{
 				Source: gotConfig.Source,
-				Period: gotConfig.Period,
+				Period: mc.gotPeriod,
 				Force:  mc.gotForce,
 				DryRun: mc.gotDryRun,
 			}
@@ -246,16 +246,18 @@ type mockCollector struct {
 	compileErr error
 	writeErr   error
 
+	gotPeriod uint32
 	gotForce  bool
 	gotDryRun bool
 }
 
-func (m *mockCollector) Compile(force bool) (collector.Insights, error) {
-	m.gotForce = force
+func (m *mockCollector) Compile() (collector.Insights, error) {
 	return collector.Insights{}, m.compileErr
 }
 
-func (m *mockCollector) Write(insights collector.Insights, dryRun bool) error {
+func (m *mockCollector) Write(insights collector.Insights, period uint32, force, dryRun bool) error {
+	m.gotPeriod = period
+	m.gotForce = force
 	m.gotDryRun = dryRun
 	return m.writeErr
 }

--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -4,6 +4,7 @@ ubuntu-insights (0.6.0) questing; urgency=medium
   * libinsights: Fix types.h references
   * libinsights: (Breaking) Rename C bindings method and type definitions
   * libinsights: Dry run collect only warns if consent file is missing
+  * libinsights: Expose collector write method
 
  -- Kat Kuo <kat.kuo@canonical.com>  Sun, 10 Aug 2025 23:49:25 -0400
 

--- a/insights/debian/libinsights0.symbols
+++ b/insights/debian/libinsights0.symbols
@@ -14,6 +14,7 @@ libinsights.so.0 libinsights0 #MINVER#
  insights_get_consent_state@Base 0.6.0
  insights_set_consent_state@Base 0.6.0
  insights_upload@Base 0.6.0
+ insights_write@Base 0.6.0
  set_displays@Base 0.5.0
  set_memory_error@Base 0.5.0
  (regex|optional).*crosscall.* 0.5.0

--- a/insights/internal/collector/testdata/TestCompile/golden/duplicate_report_force
+++ b/insights/internal/collector/testdata/TestCompile/golden/duplicate_report_force
@@ -1,8 +1,0 @@
-{
-  "insightsVersion": "Tests",
-  "collectionTime": 10,
-  "systemInfo": {
-    "hardware": {},
-    "software": {}
-  }
-}

--- a/insights/internal/collector/testdata/TestCompile/golden/period_0
+++ b/insights/internal/collector/testdata/TestCompile/golden/period_0
@@ -1,8 +1,0 @@
-{
-  "insightsVersion": "Tests",
-  "collectionTime": 10,
-  "systemInfo": {
-    "hardware": {},
-    "software": {}
-  }
-}

--- a/insights/internal/collector/testdata/TestCompile/golden/period_0_ignores_duplicates
+++ b/insights/internal/collector/testdata/TestCompile/golden/period_0_ignores_duplicates
@@ -1,8 +1,0 @@
-{
-  "insightsVersion": "Tests",
-  "collectionTime": 5,
-  "systemInfo": {
-    "hardware": {},
-    "software": {}
-  }
-}

--- a/insights/internal/collector/testdata/TestWrite/golden/period_zero_ignores_duplicates
+++ b/insights/internal/collector/testdata/TestWrite/golden/period_zero_ignores_duplicates
@@ -1,0 +1,5 @@
+local/5.json: '{"insightsVersion":"","collectionTime":0,"systemInfo":{"hardware":{},"software":{}},"sourceMetrics":{"Test Name":"Period zero ignores duplicates"}}'
+local/5.txt: ""
+local/20.json: ""
+uploaded/5.json: ""
+uploaded/30.json: ""

--- a/insights/internal/collector/testdata/TestWrite/golden/writes_reports_to_disk_if_duplicate_reports_and_force
+++ b/insights/internal/collector/testdata/TestWrite/golden/writes_reports_to_disk_if_duplicate_reports_and_force
@@ -1,0 +1,5 @@
+local/5.json: '{"insightsVersion":"","collectionTime":0,"systemInfo":{"hardware":{},"software":{}},"sourceMetrics":{"Test Name":"Writes reports to disk if duplicate reports and force"}}'
+local/5.txt: ""
+local/20.json: ""
+uploaded/5.json: ""
+uploaded/30.json: ""


### PR DESCRIPTION
This PR exposes the collector's write method in both the Go API and the C bindings. 

This is intended to be used with the changes in #202 to enable an initialization workflow where the user is shown a first report, then consent is selected, then something is written to disk. As the `write` method is intended for use with `compile` or a dry-run `collect`, it is strict with the passed report, and will error if there are any unexpected fields.

To facilitate this, duplication check logic was moved to write internally, out of report compilation. This doesn't really affect the command line behavior, as the collect command is a composite of compiling and writing. This change also has the benefit that compile now doesn't touch the disk at all.

The internal duplication check logic was modified slightly to skip dirs that don't exist instead of erroring. This allows for write to do duplication checks and while still honoring the dry run argument.