### PR TITLE
fix(collector): Remove source metrics ignoring logic for platform source

### DIFF
--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -5,6 +5,7 @@ ubuntu-insights (0.6.0) questing; urgency=medium
   * libinsights: (Breaking) Rename C bindings method and type definitions
   * libinsights: Dry run collect only warns if consent file is missing
   * libinsights: Expose collector write method
+  * libinsights: Don't ignore source metrics for platform source or empty source
 
  -- Kat Kuo <kat.kuo@canonical.com>  Sun, 10 Aug 2025 23:49:25 -0400
 

--- a/insights/internal/collector/collector.go
+++ b/insights/internal/collector/collector.go
@@ -122,12 +122,6 @@ func (c *Config) Sanitize(l *slog.Logger) error {
 		l.Info("No source provided, defaulting to platform", "source", c.Source)
 	}
 
-	if c.Source == constants.DefaultCollectSource && (c.SourceMetricsPath != "" || c.SourceMetricsJSON != nil) {
-		l.Warn("Ignoring source metrics as they are not applicable for the platform source")
-		c.SourceMetricsPath = ""
-		c.SourceMetricsJSON = nil
-	}
-
 	if c.SourceMetricsPath != "" && c.SourceMetricsJSON != nil {
 		return errors.New("only one of SourceMetricsPath or SourceMetricsJSON can be provided")
 	}

--- a/insights/internal/collector/collector_test.go
+++ b/insights/internal/collector/collector_test.go
@@ -81,28 +81,6 @@ func TestSanitize(t *testing.T) {
 				CachePath:         "fakeCachePath",
 			},
 		},
-		"Source metrics provided with empty source": {
-			config: collector.Config{
-				SourceMetricsPath: "fakeSourceMetricsPath",
-				SourceMetricsJSON: []byte(`{"test": "sourceMetricsJson"}`),
-				CachePath:         "fakeCachePath",
-			},
-			logs: map[slog.Level]uint{
-				slog.LevelInfo: 1,
-				slog.LevelWarn: 1,
-			},
-		},
-		"Source metrics provided with defaultCollectorSource": {
-			config: collector.Config{
-				Source:            constants.DefaultCollectSource,
-				SourceMetricsPath: "fakeSourceMetricsPath",
-				SourceMetricsJSON: []byte(`{"test": "sourceMetricsJson"}`),
-				CachePath:         "fakeCachePath",
-			},
-			logs: map[slog.Level]uint{
-				slog.LevelWarn: 1,
-			},
-		},
 
 		// Error cases
 		"Both sourceMetricsPath and sourceMetricsJSON provided with customSource errors": {


### PR DESCRIPTION
This PR stops source metrics from being ignored when the platform source is being used.

This is only an internal and API/Bindings change, there are no behavioral changes for the CLI due to this as it checks for the number of arguments being passed on its own.

The intention behind this change is primarily to bring more flexibility to API usage and to reduce complexity in usage. Though it's odd to be passing source metrics for the platform source, there isn't anything explicitly wrong with it. Additionally, this helps with allowing for the compile method of the collector to be exposed to the API and can help decouple it further by removing the need for a "source" at all when compiling.