### PR TITLE
feat(insights): Expose collector compile method

### DIFF
--- a/insights/C/libinsights_test.go
+++ b/insights/C/libinsights_test.go
@@ -12,6 +12,11 @@ func TestCollect(t *testing.T) {
 	main.TestCollectImpl(t)
 }
 
+// TestCompile tests C.CompileInsights.
+func TestCompile(t *testing.T) {
+	main.TestCompileImpl(t)
+}
+
 // TestWrite tests C.WriteInsights.
 func TestWrite(t *testing.T) {
 	main.TestWriteImpl(t)

--- a/insights/C/testdata/TestCompile/golden/arguments_get_converted
+++ b/insights/C/testdata/TestCompile/golden/arguments_get_converted
@@ -1,0 +1,24 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: metrics
+    sourcemetricsjson:
+        - 123
+        - 34
+        - 107
+        - 101
+        - 121
+        - 34
+        - 58
+        - 32
+        - 34
+        - 118
+        - 97
+        - 108
+        - 117
+        - 101
+        - 34
+        - 125
+outreport: ""

--- a/insights/C/testdata/TestCompile/golden/empty_values_are_empty
+++ b/insights/C/testdata/TestCompile/golden/empty_values_are_empty
@@ -1,0 +1,8 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
+outreport: ""

--- a/insights/C/testdata/TestCompile/golden/error_returns_error_string
+++ b/insights/C/testdata/TestCompile/golden/error_returns_error_string
@@ -1,0 +1,8 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
+outreport: ""

--- a/insights/C/testdata/TestCompile/golden/null_values_are_empty
+++ b/insights/C/testdata/TestCompile/golden/null_values_are_empty
@@ -1,0 +1,8 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
+outreport: ""

--- a/insights/C/testdata/TestCompile/golden/report_is_not_returned_in_error_case
+++ b/insights/C/testdata/TestCompile/golden/report_is_not_returned_in_error_case
@@ -1,0 +1,8 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
+outreport: ""

--- a/insights/C/testdata/TestCompile/golden/report_is_not_returned_when_outreport_is_nil
+++ b/insights/C/testdata/TestCompile/golden/report_is_not_returned_when_outreport_is_nil
@@ -1,0 +1,8 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
+outreport: ""

--- a/insights/C/testdata/TestCompile/golden/report_is_returned_safely_when_empty
+++ b/insights/C/testdata/TestCompile/golden/report_is_returned_safely_when_empty
@@ -1,0 +1,8 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
+outreport: ""

--- a/insights/C/testdata/TestCompile/golden/report_is_returned_when_outreport_and_outreportlen_are_provided
+++ b/insights/C/testdata/TestCompile/golden/report_is_returned_when_outreport_and_outreportlen_are_provided
@@ -1,0 +1,8 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
+outreport: '{"output": "report data"}'

--- a/insights/C/testdata/TestCompile/golden/report_return_is_safe_when_output_has_null_terminator_in_middle
+++ b/insights/C/testdata/TestCompile/golden/report_return_is_safe_when_output_has_null_terminator_in_middle
@@ -1,0 +1,8 @@
+conf:
+    consentdir: ""
+    insightsdir: ""
+    logger: null
+flags:
+    sourcemetricspath: ""
+    sourcemetricsjson: []
+outreport: '{"output": "report data with null \x00 in middle"}'

--- a/insights/C/types.h
+++ b/insights/C/types.h
@@ -32,6 +32,12 @@ typedef struct {
 } insights_collect_flags;
 
 typedef struct {
+  const char *source_metrics_path; // Path to JSON file (default: empty)
+  const void *source_metrics_json; // Raw JSON data as bytes (default: NULL)
+  size_t source_metrics_json_len;  // Length of source_metrics_json in bytes
+} insights_compile_flags;
+
+typedef struct {
   uint32_t period; // Collection period in seconds (default: 0)
   bool force;      // Force write, ignoring duplicates (default: false)
   bool dry_run;    // Simulate operation without writing files (default: false)
@@ -48,6 +54,7 @@ typedef struct {
 typedef const char insights_const_char;
 typedef const insights_config insights_const_config;
 typedef const insights_collect_flags insights_const_collect_flags;
+typedef const insights_compile_flags insights_const_compile_flags;
 typedef const insights_write_flags insights_const_write_flags;
 typedef const insights_upload_flags insights_const_upload_flags;
 

--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -5,6 +5,7 @@ ubuntu-insights (0.6.0) questing; urgency=medium
   * libinsights: (Breaking) Rename C bindings method and type definitions
   * libinsights: Dry run collect only warns if consent file is missing
   * libinsights: Expose collector write method
+  * libinsights: Expose collector compile method
   * libinsights: Don't ignore source metrics for platform source or empty source
 
  -- Kat Kuo <kat.kuo@canonical.com>  Sun, 10 Aug 2025 23:49:25 -0400


### PR DESCRIPTION
This PR exposes the collector compile method to both the Go API and to the C bindings.

The intent behind this is to provide an easier-to-use method of just getting a compiled report without writing to disk. Though this could have been achieved by passing dryrun and force to the collect methods, this method simplifies this significantly, eliminating most arguments that are only used for writing.