### PR TITLE
fix(insights): Correct ldflags version injection for shared library build

### DIFF
--- a/insights/C/generate/generate_linux.go
+++ b/insights/C/generate/generate_linux.go
@@ -30,8 +30,7 @@ func buildSharedLibs() error {
 	if version := os.Getenv("DEB_VERSION_UPSTREAM"); version != "" {
 		constants.Version = version
 	}
-
-	ldflags := fmt.Sprintf("-X=constants.Version/internal/constants.Version=%s -extldflags -Wl,-soname,%s", constants.Version, libname)
+	ldflags := fmt.Sprintf("-X=github.com/ubuntu/ubuntu-insights/insights/internal/constants.Version=%s -extldflags -Wl,-soname,%s", constants.Version, libname)
 
 	if output, err := exec.Command("go", "build", //nolint:gosec // This is controlled by the build process and also filtered here
 		"-buildmode=c-shared",


### PR DESCRIPTION
Correct ldflags version injection for shared library build