### PR TITLE
fix(insights): Update log message for consent opt-out scenario

### DIFF
--- a/insights/internal/collector/collector.go
+++ b/insights/internal/collector/collector.go
@@ -218,7 +218,7 @@ func (c collector) Write(insights Insights, period uint32, force, dryRun bool) (
 	if consent {
 		c.log.Info("Consent granted, writing insights report")
 	} else {
-		c.log.Warn("Insights data will not be written to disk, as consent was not provided.")
+		c.log.Info("Consent not granted, writing optout instead of insights report")
 		data = constants.OptOutPayload
 	}
 


### PR DESCRIPTION
This PR downgrades the opt-out log at write time from `Warn` to `Info` as this is standard business logic and not indicative of an exception. Additionally, the message itself has been rewritten for consistency and clarity.