### PR TITLE
fix(insights): Fix upload timer description to reflect 8 minutes after boot

### DIFF
--- a/insights/autostart/systemd/ubuntu-insights-upload.timer
+++ b/insights/autostart/systemd/ubuntu-insights-upload.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description="Run Ubuntu-Insights upload 5 mins after boot and every week relative to the activation time"
+Description="Run Ubuntu-Insights upload 8 mins after boot and every week relative to the activation time"
 
 [Timer]
 OnBootSec=8min


### PR DESCRIPTION
Fixes the upload systemd timer description to reflect the 8-minute post-boot timer, not 5 minutes.