### PR TITLE
docs: Cleanup repository files and documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
 # This is the squad name responsible for this project.
 
 # It will be automatically assigned to opened PR.
-
-* @ubuntu/ubuntu-insights

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Report an issue
 description: Create a bug report to fix an issue
-title: 'Issue: '
-labels: ['bug']
+title: "Issue: "
+labels: ["bug"]
 body:
   - type: markdown
     attributes:
@@ -10,20 +10,20 @@ body:
 
         Be careful with sensitive information and security vulnerabilities. In order to report bugs that could contain
         sensitive information, use [Launchpad](https://bugs.launchpad.net/ubuntu/+source/ubuntu-insights/+filebug) instead.
+        For security vulnerabilities, see our [security policy](https://github.com/ubuntu/ubuntu-insights/security).
         On Ubuntu machines, you can use `ubuntu-bug ubuntu-insights` to collect relevant information.
 
 
         Thanks for taking the time to report an issue and help improve Ubuntu Insights! Please fill out the form below as
         best as you can so that we can help you.
 
+
         Your additional work here is greatly appreciated and will help us respond as quickly as possible. For general
         support or usage questions, use [Ubuntu Discourse](https://discourse.ubuntu.com/c/desktop/8).
 
+
         By submitting an Issue to this repository, you agree to the terms within the
         [Ubuntu Code of Conduct](https://ubuntu.com/community/code-of-conduct).
-
-
-        FIXME: snap?
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?
@@ -35,11 +35,12 @@ body:
       label: Describe the issue
       description: >
         Provide a clear and concise description of what the issue is, including what you expected to happen.
+        Please include what the triggering source was if applicable (CLI, systemd, libraries, etc.)
     validations:
       required: true
   - type: textarea
     attributes:
-      label: Steps to reproduce it
+      label: Steps to reproduce
       description: >
         Detail the steps taken to reproduce this error, what was expected, and whether this issue can be reproduced
         consistently or if it is intermittent.
@@ -54,34 +55,66 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: "Ubuntu users: System information and logs"
-      description: >
-        Ubuntu users can run `ubuntu-bug ubuntu-insights --save=/tmp/report.txt` and drag the file below.
-        It will contain any useful information.
-  - type: textarea
-    attributes:
-      label: "Non Ubuntu users: System information and logs"
+      label: "System information and logs"
       description: |
-        For users of other distributions than ubuntu, provide details about the environment you experienced the issue in:
-      value: |
-        ### Environment
-        * Ubuntu Insights version: please run TODO
-        * Distribution: (**NAME** in `/etc/os-release`)
-        * Distribution version: (**VERSION_ID** on `/etc/os-release`):
+        Please include all relevant system information and logs that can help us diagnose the issue, including consent configuration files.
 
-        ### Log files
-        Please redact/remove sensitive information:
-        ```raw
-        TODO: how to collect them
+        To get debug output from the CLI, run the command with the `-vv` flag.
+
+        For library or bindings bugs, get the logs by setting the appropriate log level through the API.
+
+        By default, consent configuration files are located in:
+        - `~/.config/ubuntu-insights/` on Linux systems
+        - `~/Library/Application Support/ubuntu-insights/` on macOS systems
+        - `%appdata%\ubuntu-insights\` on Windows systems
+
+        If this bug report pertains to the Ubuntu `ubuntu-insights` package, you may copy and paste the following command to make collection of relevant information easier. It will open a text editor with the system information, relevant logs, and consent configuration files. Paste the output below. Redact any sensitive information from the output.
+        ```bash
+        sudo -v
+        TMPFILE=$(mktemp ubuntu-insights-system-info-XXXXXX.md)
+        if command -v xdg-open > /dev/null && [ -n "${DISPLAY:-}" ]; then insights_editor=xdg-open; elif [ -n "${EDITOR:-}" ]; then insights_editor="$EDITOR"; fi
+        cat > "$TMPFILE" <<EOF && ${insights_editor:-editor} "$TMPFILE"
+        #### ubuntu-insights version
+        \`\`\`
+        $(/usr/bin/ubuntu-insights --version)
+        \`\`\`
+
+        #### Distribution
+        \`\`\`
+        $(lsb_release -a)
+        \`\`\`
+
+        #### Systemd Collect Logs
+        \`\`\`
+        $(journalctl --user -u ubuntu-insights-collect.service -u ubuntu-insights-collect.timer -n 1000 -o short-monotonic)
+        \`\`\`
+
+        #### Systemd Upload Logs
+        \`\`\`
+        $(journalctl --user -u ubuntu-insights-upload.service -u ubuntu-insights-upload.timer -n 1000 -o short-monotonic)
+        \`\`\`
+
+        #### ubuntu-insights apt history
+        \`\`\`
+        $(awk -v RS= -v ORS="\n\n" '/ubuntu-insights/' /var/log/apt/history.log)
+        \`\`\`
+
+        #### Default consent configuration folder contents
+        \`\`\`
+        $(if [ -d "$HOME/.config/ubuntu-insights" ]; then
+          find "$HOME/.config/ubuntu-insights" -type f | while read -r file; do
+            echo "----- $file -----"
+            cat "$file"
+            echo
+          done
+        else
+          echo "No ~/.config/ubuntu-insights directory found."
+        fi)
+        \`\`\`
+        EOF
         ```
-
-        ### Application settings
-        Please redact/remove sensitive information:
-        ```raw
-        TODO: how to collect them
-        ```
-
-        FIXME: snap?
+      placeholder: >
+        Paste your system info and logs here. Redact any sensitive information.
   - type: textarea
     attributes:
       label: Relevant information
@@ -97,4 +130,3 @@ body:
       options:
         - label: I have redacted any sensitive information from the logs
           required: true
-

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Request a feature
 description: Suggest new functionality or improvements for this project
-title: 'Feature: '
-labels: ['feature']
+title: "Feature: "
+labels: ["feature"]
 body:
   - type: markdown
     attributes:
@@ -10,20 +10,20 @@ body:
 
         Be careful with sensitive information and security vulnerabilities. In order to report bugs that could contain
         sensitive information, use [Launchpad](https://bugs.launchpad.net/ubuntu/+source/ubuntu-insights/+filebug) instead.
+        For security vulnerabilities, see our [security policy](https://github.com/ubuntu/ubuntu-insights/security).
         On Ubuntu machines, you can use `ubuntu-bug ubuntu-insights` to collect relevant information.
 
 
         Thanks for taking the time to report an issue and help improve Ubuntu Insights! Please fill out the form below as
         best as you can so that we can help you.
 
+
         Your additional work here is greatly appreciated and will help us respond as quickly as possible. For general
         support or usage questions, use [Ubuntu Discourse](https://discourse.ubuntu.com/c/desktop/8).
 
+
         By submitting an Issue to this repository, you agree to the terms within the
         [Ubuntu Code of Conduct](https://ubuntu.com/community/code-of-conduct).
-
-
-        FIXME: snap?
   - type: checkboxes
     attributes:
       label: Is there an existing request for this feature?
@@ -48,48 +48,3 @@ body:
       description: >
         A clear and concise description of any alternatives you've considered or any workarounds that are currently in
         place.
-  - type: textarea
-    attributes:
-      label: "Ubuntu users: System information and logs"
-      description: >
-        Ubuntu users can run `ubuntu-bug ubuntu-insights --save=/tmp/report.txt` and drag the file below.
-        It will contain any useful information.
-  - type: textarea
-    attributes:
-      label: "Non Ubuntu users: System information and logs"
-      description: |
-        For users of other distributions than ubuntu, provide details about the environment you experienced the issue in:
-      value: |
-        ### Environment
-        * Ubuntu Insights version: please run TODO
-        * Distribution: (**NAME** in `/etc/os-release`)
-        * Distribution version: (**VERSION_ID** on `/etc/os-release`):
-
-        ### Log files
-        Please redact/remove sensitive information:
-        ```raw
-        TODO: how to collect them
-        ```
-
-        ### Application settings
-        Please redact/remove sensitive information:
-        ```raw
-        TODO: how to collect them
-        ```
-
-        FIXME: snap?
-  - type: textarea
-    attributes:
-      label: Relevant information
-      description: >
-        Please look at our
-        [Ubuntu Insights Troubleshooting guide](../#troubleshooting)
-        and provide the debug logs for Ubuntu Insights.
-
-      placeholder: Remember to redact any sensitive information from them.
-  - type: checkboxes
-    attributes:
-      label: Double check your logs
-      options:
-        - label: I have redacted any sensitive information from the logs
-          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,14 @@ These are mostly guidelines, not rules. Use your best judgment, and feel free to
 
 - [Code of Conduct](#code-of-conduct)
 - [Getting Started](#getting-started)
-- [Issues](#issues)
-- [Pull Requests](#pull-requests)
+    - [Issues](#issues)
+    - [Pull Requests](#pull-requests)
 - [Contributing to the code](#contributing-to-the-code)
+    - [Required dependencies](#required-dependencies)
+    - [Building and running the binaries](#building-and-running-the-binaries)
+    - [About the test suite](#about-the-test-suite)
+      - [Tests with dependencies](#tests-with-dependencies)
+    - [Code style](#code-style)
 - [Contributor License Agreement](#contributor-license-agreement)
 - [Getting Help](#getting-help)
 
@@ -24,7 +29,7 @@ We take our community seriously and hold ourselves and other contributors to hig
 
 Contributions are made to this project via Issues and Pull Requests (PRs). A few general guidelines that cover both:
 
-- To report security vulnerabilities, please use the advisories page of the repository and not a public bug report. Please use [launchpad private bugs](https://bugs.launchpad.net/ubuntu/+source/Ubuntu-Insights/+filebug) which is monitored by our security team. On an ubuntu machine, it’s best to use `ubuntu-bug Ubuntu Insights` to collect relevant information. FIXME: snap?
+- To report security vulnerabilities, please use the advisories page of the repository and not a public bug report. Please use [launchpad private bugs](https://bugs.launchpad.net/ubuntu/+source/ubuntu-insights/+filebug) which is monitored by our security team. Alternatively, use the repository's [security page](https://github.com/ubuntu/ubuntu-insights/security). On an Ubuntu machine, it’s best to use `ubuntu-bug ubuntu insights` to collect relevant information.
 - Search for existing Issues and PRs on this repository before creating your own.
 - We work hard to makes sure issues are handled in a timely manner but, depending on the impact, it could take a while to investigate the root cause. A friendly ping in the comment thread to the submitter or a contributor can help draw attention if your issue is blocking.
 - If you've never contributed before, see [this Ubuntu resource post](https://ubuntu.com/community/contribute) for resources and tips on how to get started.
@@ -65,25 +70,95 @@ Once merged to the main branch, `po` files and any documentation change will be 
 
 ### Required dependencies
 
-TODO
+This project has several build dependencies. On Ubuntu, you can install these dependencies from the `insights/` directory using the apt command as follows:
+
+```bash
+sudo apt update
+sudo apt build-dep .
+sudo apt install devscripts
+```
+
+On other operating systems, you will need [Go](https://go.dev/) at a minimum.
 
 ### Building and running the binaries
 
-TODO
+This repository is set up in a mono-repo structure, and consists of multiple modules and binaries.
 
-### About the testsuite
+- `insights/`: The client
+  - `ubuntu-insights`: The CLI
+  - `libinsights.so`/`libinsights.dll`: C shared/dynamic library
+- `server/`: Server services
+  - `web-service`: Server HTTP server service
+  - `ingest-service`: Server database ingest service
+- `common/`: A helper shared Go package dependency
 
-The project includes a comprehensive testsuite made of unit and integration tests. All the tests must pass before the review is considered. If you have troubles with the testsuite, feel free to mention it on your PR description.
+The project's client components can be built as a Debian package. This process will compile all the client-side binaries, run the test suite and produce the Debian packages.
 
-TODO
+Alternatively, for development purposes or for the server services, each binary can be built manually and separately.
+
+#### Building the client Debian packages from source
+
+Building the Debian packages from source is the most straightforward and standard method for compiling the binaries and running the test suite. To do this, run the following command from `insights/` folder of the source tree:
+
+```shell
+debuild
+```
+
+The Debian packages are available in the parent directory.
+
+#### Building the CLIs only
+
+To build a CLI only, either the client, or a server service, run the appropriate command from the top of the source tree.
+The resulting binary will be found in the current directory, and can be run directly without needing to be installed.
+
+##### Client
+
+```shell
+go build -o ubuntu-insights ./insights/cmd/insights
+```
+
+##### Web Service
+
+```shell
+go build ./server/cmd/web-service
+```
+
+##### Ingest Service
+
+```shell
+go build ./server/cmd/ingest-service
+```
+
+#### Building C bindings only
+
+To build the C bindings only, run the following command from the top of the source tree:
+
+```shell
+go generate ./insights/C/...
+```
+
+The resulting binaries and associated C header files will be in the `insights/generated/` folder.
+
+### About the test suite
+
+The project includes a comprehensive test suite made of unit and integration tests. All the tests must pass before the review is considered. If you have troubles with the test suite, feel free to mention it on your PR description.
+
+To run all tests for a given module, from the module's root folder (i.e., `insights/`, `server/`, or `common/`), run: `go test ./...` (add the `-race` flag for race detection).
 
 The test suite must pass before merging the PR to our main branch. Any new feature, change or fix must be covered by corresponding tests.
 
+#### Tests with dependencies
+
+Some server integration tests use the [Testcontainers Go package](https://golang.testcontainers.org/) which requires a [Docker-API compatible container runtime](https://golang.testcontainers.org/system_requirements/docker/).
+
+These special test dependencies are not included in the project dependencies and must be installed manually.
+
 ### Code style
 
-This project follow the TODO code-style. For more informative information about the code style in use, please check:
+This project follow the Go code-style. The client C bindings roughly follow the GNU code-style. For more informative information about the code style in use, please check:
 
-- For go: <https://google.github.io/styleguide/go/>
+- For Go: <https://google.github.io/styleguide/go/>
+- For C: <https://www.gnu.org/prep/standards/html_node/Writing-C.html>
 
 ## Contributor License Agreement
 
@@ -91,7 +166,7 @@ It is required to sign the [Contributor License Agreement](https://ubuntu.com/le
 
 An automated test is executed on PRs to check if it has been accepted.
 
-This project is covered by [THIS LICENSE](LICENSE).
+This project is covered by [GPL-3.0](LICENSE).
 
 ## Getting Help
 

--- a/insights/README.md
+++ b/insights/README.md
@@ -1,6 +1,11 @@
 # Ubuntu Insights Client
 
-The Ubuntu Insights Client is the component responsible for handling all local Ubuntu Insights actions. This component includes a command-line interface, a Go and C API, as well as the source for the `ubuntu-insights` deb package. 
+[reference-documentation-image]: https://pkg.go.dev/badge/github.com/ubuntu/ubuntu-insights/insights.svg
+[reference-documentation-url]: https://pkg.go.dev/github.com/ubuntu/ubuntu-insights/insights
+
+[![Go Reference][reference-documentation-image]][reference-documentation-url]
+
+The Ubuntu Insights Client is the component responsible for handling all local Ubuntu Insights actions. This component includes a command-line interface, a Go and C API, as well as the source for the `ubuntu-insights` deb package.
 
 ## About
 
@@ -141,6 +146,4 @@ These commands are hidden from help, and should primarily be used by the system 
 
 Generate the autocompletion script for ubuntu-insights for the specified shell.
 
-`
-  ubuntu-insights completion [shell]
-`
+`  ubuntu-insights completion [shell]`


### PR DESCRIPTION
This PR cleans up various repository files and repository-level documentation.
- Bug report template
   - Remove references to snaps
   - Add additional instructions on getting relevant information, including an optional script for Ubuntu users
   - Add references to the security policy
- Feature request template
   - Remove references to snaps
   - Remove unnecessary sections
   - Add references to the security policy
-  `CONTRIBUTING.md`
	- Add dependency information
	- Add build instruction
	- Add information about the test suite
	- Add code style information
	- Add references to the security policy
	- Fix broken Launchpad link
 - Add Go reference documentation badge to `insights/` README
 - Remove bad entry from CODEOWNERS file

---
[UDENG-7298](https://warthogs.atlassian.net/browse/UDENG-7298)

[UDENG-7298]: https://warthogs.atlassian.net/browse/UDENG-7298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ