### PR TITLE
fix(insights): Fix systemd permissions error in certain environments

### DIFF
--- a/insights/autostart/systemd/ubuntu-insights-collect.service
+++ b/insights/autostart/systemd/ubuntu-insights-collect.service
@@ -10,8 +10,9 @@ SuccessExitStatus=1
 
 # Containment
 ProtectSystem=strict
-ProtectHome=yes
-ReadWritePaths=%h/.config %h/.cache
+ProtectHome=tmpfs
+BindPaths=%h/.config %h/.cache
+BindReadOnlyPaths=/run/user/%U
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=true

--- a/insights/autostart/systemd/ubuntu-insights-upload.service
+++ b/insights/autostart/systemd/ubuntu-insights-upload.service
@@ -9,8 +9,8 @@ SuccessExitStatus=1
 
 # Containment
 ProtectSystem=strict
-ProtectHome=yes
-ReadWritePaths=%h/.config %h/.cache
+ProtectHome=tmpfs
+BindPaths=%h/.config %h/.cache
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
 NoNewPrivileges=true


### PR DESCRIPTION
In certain environments, collections triggered by systemd fail due to a permissions error when trying to create the `~/.cache/ubuntu-insights folder`. It is likely this happens with other folders as well. This only occurs with systemd-triggered collections and does not occur when running the same command without systemd containment. Additionally, it also appears not to be an issue on Plucky or Questing, though this could be due to the test environment not triggering `ProtectHome`.

```
ERROR failed to collect insights: failed to create cache directory: mkdir ~: permission denied
```

This PR resolves this issue while preserving the same containment score as before. 

---
[UDENG-7697](https://warthogs.atlassian.net/browse/UDENG-7697)


[UDENG-7697]: https://warthogs.atlassian.net/browse/UDENG-7697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ