### PR TITLE
fix(insights): Fix misleading "No source provided" log when using Compile

### DIFF
--- a/insights/api.go
+++ b/insights/api.go
@@ -145,6 +145,7 @@ func (c Config) Compile(flags CompileFlags) ([]byte, error) {
 	r := c.Resolve()
 
 	cConf := collector.Config{
+		Source:            constants.DefaultCollectSource, // TODO: remove following Not actually used, this is to prevent misleading logs.
 		CachePath:         r.InsightsDir,
 		SourceMetricsPath: flags.SourceMetricsPath,
 		SourceMetricsJSON: flags.SourceMetricsJSON,


### PR DESCRIPTION
This PR prevents the misleading log "No source provided, defaulting to platform" from being printed when using `Compile` via either the Go API or C bindings. Since `source` has no meaning when using `Compile`, this message does not make sense.

This is only a workaround for now until the collector is refactored. Currently, this message is caused by the sanitation of the collector config when a new collector is being made. If the source is not set at sanitation time, then this message is logged. Since `source` is meaningless when only compiling, this workaround just sets it to an arbitrary value.