### PR TITLE
fix(ingest-service): Fix potential leaking of credentials in logs 

### DIFF
--- a/server/cmd/ingest-service/daemon/daemon.go
+++ b/server/cmd/ingest-service/daemon/daemon.go
@@ -168,7 +168,7 @@ func (a *App) run() (err error) {
 		return fmt.Errorf("failed to get absolute path for allowlist file: %v", err)
 	}
 	cm := config.New(a.allowlistPath)
-	db, err := database.Connect(context.Background(), a.config.DBconfig)
+	db, err := database.New(context.Background(), a.config.DBconfig)
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %v", err)
 	}

--- a/server/cmd/ingest-service/daemon/daemon_test.go
+++ b/server/cmd/ingest-service/daemon/daemon_test.go
@@ -105,7 +105,7 @@ func TestAppCanSigHupAfterExecute(t *testing.T) {
 	allowlistPath := daemon.GenerateTestAllowlist(t, &config.Conf{})
 	a, wait := startDaemon(t, nil, allowlistPath)
 	a.Quit()
-	wait(false)
+	wait(true)
 
 	orig := os.Stdout
 	os.Stdout = w

--- a/server/cmd/ingest-service/daemon/migrate.go
+++ b/server/cmd/ingest-service/daemon/migrate.go
@@ -51,22 +51,9 @@ If no path is provided, the default path is used.`,
 }
 
 func (a App) migrateRun() error {
-	dbCfg := a.config.DBconfig
-
-	// Convert config to DSN format
-	dsn := fmt.Sprintf(
-		"pgx://%s:%s@%s:%d/%s?sslmode=%s",
-		dbCfg.User,
-		dbCfg.Password, // can be empty for some auth methods
-		dbCfg.Host,
-		dbCfg.Port,
-		dbCfg.DBName,
-		dbCfg.SSLMode,
-	)
-
 	m, err := migrate.New(
 		fmt.Sprintf("file://%s", a.config.MigrationsDir),
-		dsn, // Convert DSN
+		a.config.DBconfig.URI("pgx"),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create migration instance: %v", err)

--- a/server/internal/ingest/database/database_test.go
+++ b/server/internal/ingest/database/database_test.go
@@ -14,11 +14,12 @@ import (
 	"github.com/ubuntu/ubuntu-insights/server/internal/ingest/models"
 )
 
-func TestConnect(t *testing.T) {
+func TestNew(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		config database.Config
+		config  database.Config
+		pingErr error
 
 		wantErr bool
 	}{
@@ -42,7 +43,7 @@ func TestConnect(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			mgr, err := database.Connect(t.Context(), tc.config, database.WithNewPool(mockNewDBPool(t, mockDBPool{})))
+			mgr, err := database.New(t.Context(), tc.config, database.WithNewPool(mockNewDBPool(t, mockDBPool{pingErr: tc.pingErr})))
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("Connect() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -90,7 +91,7 @@ func TestUpload(t *testing.T) {
 				execErr: tc.execErr,
 			}
 
-			mgr, err := database.Connect(t.Context(), database.Config{}, database.WithNewPool(mockNewDBPool(t, dbPool)))
+			mgr, err := database.New(t.Context(), database.Config{}, database.WithNewPool(mockNewDBPool(t, dbPool)))
 			require.NoError(t, err, "Setup: Connect() error")
 			defer mgr.Close()
 
@@ -148,7 +149,7 @@ func TestUploadLegacy(t *testing.T) {
 				execErr: tc.execErr,
 			}
 
-			mgr, err := database.Connect(t.Context(), database.Config{}, database.WithNewPool(mockNewDBPool(t, dbPool)))
+			mgr, err := database.New(t.Context(), database.Config{}, database.WithNewPool(mockNewDBPool(t, dbPool)))
 			require.NoError(t, err, "Setup: Connect() error")
 			defer mgr.Close()
 
@@ -208,7 +209,7 @@ func TestUploadInvalid(t *testing.T) {
 				execErr: tc.execErr,
 			}
 
-			mgr, err := database.Connect(t.Context(), database.Config{}, database.WithNewPool(mockNewDBPool(t, dbPool)))
+			mgr, err := database.New(t.Context(), database.Config{}, database.WithNewPool(mockNewDBPool(t, dbPool)))
 			require.NoError(t, err, "Setup: Connect() error")
 			defer mgr.Close()
 
@@ -256,7 +257,7 @@ func TestClose(t *testing.T) {
 				closeDelay: tc.closeDelay,
 			}
 
-			mgr, err := database.Connect(t.Context(), database.Config{}, database.WithNewPool(mockNewDBPool(t, dbPool)))
+			mgr, err := database.New(t.Context(), database.Config{}, database.WithNewPool(mockNewDBPool(t, dbPool)))
 			require.NoError(t, err, "Setup: Connect() error")
 			defer mgr.Close()
 
@@ -288,11 +289,16 @@ func mockNewDBPool(t *testing.T, dbPool mockDBPool) func(ctx context.Context, ds
 
 type mockDBPool struct {
 	execErr    error
+	pingErr    error
 	closeDelay time.Duration
 }
 
 func (m mockDBPool) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
 	return pgconn.CommandTag{}, m.execErr
+}
+
+func (m mockDBPool) Ping(ctx context.Context) error {
+	return m.pingErr
 }
 
 func (m mockDBPool) Close() {

--- a/server/internal/ingest/database/database_test.go
+++ b/server/internal/ingest/database/database_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/ubuntu-insights/common/testutils"
 	"github.com/ubuntu/ubuntu-insights/server/internal/ingest/database"
 	"github.com/ubuntu/ubuntu-insights/server/internal/ingest/models"
 )
@@ -270,6 +271,78 @@ func TestClose(t *testing.T) {
 
 			// No error after second close
 			require.NoError(t, mgr.Close(), "Close should not error on second call")
+		})
+	}
+}
+
+func TestURI(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		config database.Config
+		scheme string
+	}{
+		"basic config": {
+			config: database.Config{
+				Host:     "localhost",
+				Port:     5432,
+				User:     "testuser",
+				Password: "testpassword",
+				DBName:   "testdb",
+				SSLMode:  "disable",
+			},
+			scheme: "postgres",
+		},
+		"handles no port": {
+			config: database.Config{
+				Host:     "localhost",
+				User:     "testuser",
+				Password: "testpassword",
+				DBName:   "testdb",
+				SSLMode:  "disable",
+			},
+			scheme: "postgres",
+		},
+		"handles no password": {
+			config: database.Config{
+				Host:    "localhost",
+				Port:    5432,
+				User:    "testuser",
+				DBName:  "testdb",
+				SSLMode: "disable",
+			},
+			scheme: "postgres",
+		},
+		"handles no sslmode": {
+			config: database.Config{
+				Host:     "localhost",
+				Port:     5432,
+				User:     "testuser",
+				Password: "testpassword",
+				DBName:   "testdb",
+			},
+			scheme: "postgres",
+		},
+		"handles custom scheme": {
+			config: database.Config{
+				Host:     "localhost",
+				Port:     5432,
+				User:     "testuser",
+				Password: "testpassword",
+				DBName:   "testdb",
+				SSLMode:  "disable",
+			},
+			scheme: "pgx",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.config.URI(tc.scheme)
+			want := testutils.LoadWithUpdateFromGolden(t, got)
+			require.Equal(t, want, got, "URI() output does not match golden file")
 		})
 	}
 }

--- a/server/internal/ingest/database/testdata/TestURI/golden/basic_config
+++ b/server/internal/ingest/database/testdata/TestURI/golden/basic_config
@@ -1,0 +1,1 @@
+postgres://testuser:testpassword@localhost:5432/testdb?sslmode=disable

--- a/server/internal/ingest/database/testdata/TestURI/golden/handles_custom_scheme
+++ b/server/internal/ingest/database/testdata/TestURI/golden/handles_custom_scheme
@@ -1,0 +1,1 @@
+pgx://testuser:testpassword@localhost:5432/testdb?sslmode=disable

--- a/server/internal/ingest/database/testdata/TestURI/golden/handles_no_password
+++ b/server/internal/ingest/database/testdata/TestURI/golden/handles_no_password
@@ -1,0 +1,1 @@
+postgres://testuser@localhost:5432/testdb?sslmode=disable

--- a/server/internal/ingest/database/testdata/TestURI/golden/handles_no_port
+++ b/server/internal/ingest/database/testdata/TestURI/golden/handles_no_port
@@ -1,0 +1,1 @@
+postgres://testuser:testpassword@localhost/testdb?sslmode=disable

--- a/server/internal/ingest/database/testdata/TestURI/golden/handles_no_sslmode
+++ b/server/internal/ingest/database/testdata/TestURI/golden/handles_no_sslmode
@@ -1,0 +1,1 @@
+postgres://testuser:testpassword@localhost:5432/testdb


### PR DESCRIPTION
This PR fixes a number of potential leaks of database credentials in logs.

 - The parsed config in the logs when starting the ingest service now redacts the password first.
 - URI building for both standard operation and for the migrate command has been reworked to improve its reciliency.
 	-  This change prevents a situation where errors would cause leaks should a password but no user be passed to the service.