### PR TITLE
fix(server): Change the default reports dir to use the user cache path

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -33,7 +33,7 @@ Flags:
       --metrics-host string        host for the metrics endpoint
       --metrics-port int           port for the metrics endpoint (default 2112)
       --read-timeout duration      read timeout for HTTP server (default 5s)
-      --reports-dir string         directory to store reports in (default "/var/lib/ubuntu-insights-services/reports")
+      --reports-dir string         directory to store reports in (default "~/.cache/ubuntu-insights-services~/reports")
       --request-timeout duration   request timeout for HTTP server (default 3s)
   -v, --verbose count              issue INFO (-v), DEBUG (-vv)
       --write-timeout duration     write timeout for HTTP server (default 10s)
@@ -67,7 +67,7 @@ Flags:
       --metrics-host string      host for the metrics endpoint
       --metrics-port int         port for the metrics endpoint (default 2113)
       --read-timeout duration    read timeout for the metrics HTTP server (default 5s)
-      --reports-dir string       base directory to read reports from (default "/var/lib/ubuntu-insights-services/reports")
+      --reports-dir string       base directory to read reports from (default "~/.cache/ubuntu-insights-services/reports")
   -v, --verbose count            issue INFO (-v), DEBUG (-vv)
       --write-timeout duration   write timeout for the metrics HTTP server (default 10s)
 ```

--- a/server/internal/common/constants/constants.go
+++ b/server/internal/common/constants/constants.go
@@ -3,6 +3,8 @@
 package constants
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 )
 
@@ -34,8 +36,18 @@ const (
 // Service variables.
 var (
 	// DefaultServiceDataDir is the default data directory for services.
-	DefaultServiceDataDir = filepath.Join("/var/lib", DefaultServiceFolder)
+	DefaultServiceDataDir = DefaultServiceFolder
 
 	// DefaultServiceReportsDir is the default reports directory for services.
 	DefaultServiceReportsDir = filepath.Join(DefaultServiceDataDir, DefaultServiceReportsFolder)
 )
+
+func init() {
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		panic(fmt.Sprintf("Could not fetch cache directory: %v", err))
+	}
+
+	DefaultServiceDataDir = filepath.Join(userCacheDir, DefaultServiceFolder)
+	DefaultServiceReportsDir = filepath.Join(DefaultServiceDataDir, DefaultServiceReportsFolder)
+}


### PR DESCRIPTION
This PR changes the default reports dir to use the user cache path. This may be a breaking change.

While it is expected that most users will set this manually (like how it is in the charm currently), the previous default value required the services to be run as root or for the default directory to already exist with special permissions set up to allow for the services to read and write to them. Since we don't package and ship the binaries outside a charm, this isn't something that can be automated.

By using `~/.cache/` instead, we get around this and remove the requirement to run the service as root or do extra setup when using the default value.