### PR TITLE
ci: Refactor QA & sanity checks workflow and add TiCS integration

### DIFF
--- a/.github/actions/prepare-environment/action.yaml
+++ b/.github/actions/prepare-environment/action.yaml
@@ -12,10 +12,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: setup-go cache workaround #https://github.com/actions/setup-go/issues/424
-      shell: bash
-      run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
-
     - name: Set up Go
       uses: actions/setup-go@v6
       with:

--- a/.github/actions/prepare-environment/action.yaml
+++ b/.github/actions/prepare-environment/action.yaml
@@ -1,0 +1,35 @@
+name: Prepare environment for CI
+description: Prepare the environment for CI by preparing and installing common dependencies.
+
+inputs:
+  working-directory:
+    description: Directory where the action is ran. All other paths are relative to this one. The `go.work` file is expected to be in this directory.
+    default: "."
+  apt-dependencies:
+    description: A space-separated list of apt dependencies to install (Ignored if not using a Linux runner).
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: setup-go cache workaround #https://github.com/actions/setup-go/issues/424
+      shell: bash
+      run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: ${{ inputs.working-directory }}/go.work
+        cache-dependency-path: |
+          ${{ inputs.working-directory }}/insights/go.sum
+          ${{ inputs.working-directory }}/server/go.sum
+          ${{ inputs.working-directory }}/common/go.sum
+          ${{ inputs.working-directory }}/tools/go.sum
+
+    - name: Install dependencies on Linux
+      if: runner.os == 'Linux' && inputs.apt-dependencies != ''
+      shell: bash
+      run: |
+        set -e
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ${{ inputs.apt-dependencies }}

--- a/.github/workflows/lrc-qa.yaml
+++ b/.github/workflows/lrc-qa.yaml
@@ -73,17 +73,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: setup-go cache workaround #https://github.com/actions/setup-go/issues/424
-        shell: bash
-        run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.work
-          cache-dependency-path: |
-            insights/go.sum
-            server/go.sum
-            common/go.sum
-            tools/go.sum
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-environment
 
       - name: Vendor Go modules
         working-directory: insights

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -9,131 +9,159 @@ on:
 
 env:
   DEBIAN_FRONTEND: noninteractive
-  GO_TESTS_TIMEOUT: 20m
-  insights_apt_deps: "libwayland-dev"
+  GO_TESTS_TIMEOUT: 30m
+  INSIGHTS_APT_DEPS: "libwayland-dev"
+  # RAW_MATRIX defines the OS/module matrix for jobs.
+  # The "server" module only supports ubuntu.
+  RAW_MATRIX: |
+    {
+      "os": ["ubuntu-24.04", "windows-2022", "macos-13", "macos-14"],
+      "module": ["insights", "common"],
+      "include": [
+        {"os": "ubuntu-24.04", "module": "server"}
+      ]
+    }
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
+  plan:
+    name: Create test plan # Dynamic matrix generation for subsequent jobs
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          echo "matrix=$(echo "${RAW_MATRIX}" | jq -c .)"  >> $GITHUB_OUTPUT
+
   go-sanity:
     name: "Go: Code sanity"
+    needs: plan
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, windows-2022, macos-13, macos-14] # Run on Ubuntu, Windows, Mac Intel, Mac ARM
-        subproject: ["insights", "common"]
-        include:
-          - os: ubuntu-24.04
-            subproject: server # server is only supported on Linux
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
       - name: Install dependencies on Linux
-        if: runner.os == 'Linux' && matrix.subproject == 'insights'
+        if: runner.os == 'Linux' && matrix.module == 'insights'
         run: |
           sudo apt update
-          sudo apt install -y ${{ env.insights_apt_deps }}
+          sudo apt install -y ${{ env.INSIGHTS_APT_DEPS }}
       - uses: actions/checkout@v5
       - name: Go code sanity check
         uses: canonical/desktop-engineering/gh-actions/go/code-sanity@v2
         with:
-          working-directory: ${{ matrix.subproject }}
+          working-directory: ${{ matrix.module }}
           tools-directory: ${{ github.workspace }}/tools
           golangci-lint-configfile: ${{ github.workspace }}/.golangci.yaml
-  go-tests:
-    name: "Go: Tests"
+
+  go-race-tests:
+    name: "Go: Race Tests"
+    needs: plan
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        test: ["coverage", "race"]
-        os: [ubuntu-24.04, windows-2022, macos-13, macos-14] # Run on Ubuntu, Windows, Mac Intel, Mac ARM
-        subproject: ["insights", "common"]
-        include:
-          - os: ubuntu-24.04
-            subproject: server # server is only supported on Linux
-            test: coverage
-          - os: ubuntu-24.04
-            subproject: server # server is only supported on Linux
-            test: race
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v5
       - name: Prepare environment
         uses: ./.github/actions/prepare-environment
         with:
-          apt-dependencies: ${{ env.insights_apt_deps }}
+          apt-dependencies: ${{ env.INSIGHTS_APT_DEPS }}
 
       - name: Install gotestfmt and our wrapper script
         uses: canonical/desktop-engineering/gh-actions/go/gotestfmt@main
 
+      - name: Prepare test artifacts path
+        run: |
+          set -euo pipefail
+
+          artifacts_dir=${RUNNER_TEMP}/test-artifacts
+          mkdir -p "${artifacts_dir}"
+          echo TEST_ARTIFACTS_PATH="${artifacts_dir}" >> $GITHUB_ENV
+
+      - name: Run tests (with race detector)
+        working-directory: ${{ matrix.module }}
+        run: |
+          set -euo pipefail
+
+          # -json will sometimes write non-json warnings to stdout, especially on macOS with -race
+          # CGO_LDFLAGS="-w" could be set to suppress linker warnings, but it is better to see them.
+          # See https://github.com/golang/go/issues/74978 and https://github.com/golang/go/issues/61229 
+          # Print executed commands to ease debugging
+
+          go test -json -timeout "${GO_TESTS_TIMEOUT}" -race ./... \
+            | tee >(jq -r 'select(.Action == "build-output") | "WARNING: Build output action filtered out -> \(. | tostring)"' >&2) \
+            | jq -c 'select(.Action != "build-output")' \
+            | gotestfmt --logfile "${TEST_ARTIFACTS_PATH}/gotestfmt.race.log"
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: insights-${{ github.job }}-${{ matrix.module }}-${{ matrix.os }}-artifacts-${{ github.run_attempt }}
+          path: ${{ env.TEST_ARTIFACTS_PATH }}
+
+  go-coverage-tests:
+    name: "Go: Coverage Tests"
+    needs: plan
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-environment
+        with:
+          apt-dependencies: ${{ env.INSIGHTS_APT_DEPS }}
+
       - name: Install coverage test dependencies
-        shell: bash
-        if: matrix.test == 'coverage'
         run: |
           go install github.com/AlekSi/gocov-xml@latest
           go install github.com/axw/gocov/gocov@latest
 
-      - name: Prepare tests artifacts path
+      - name: Install gotestfmt and our wrapper script
+        uses: canonical/desktop-engineering/gh-actions/go/gotestfmt@main
+
+      - name: Prepare test artifacts path
         run: |
           set -euo pipefail
 
-          artifacts_dir=$(mktemp -d -t insights-test-artifacts-XXXXXX)
-          echo INSIGHTS_TEST_ARTIFACTS_PATH="${artifacts_dir}" >> $GITHUB_ENV
-        shell: bash
+          artifacts_dir=${RUNNER_TEMP}/test-artifacts
+          mkdir -p "${artifacts_dir}"
+          echo TEST_ARTIFACTS_PATH="${artifacts_dir}" >> $GITHUB_ENV
 
       - name: Run tests (with coverage collection)
-        if: matrix.test == 'coverage'
-        env:
-          G_DEBUG: "fatal-criticals"
-        working-directory: ${{ matrix.subproject }}
+        working-directory: ${{ matrix.module }}
         run: |
           set -euo pipefail
 
-          cov_dir=$(pwd)/coverage
+          cov_dir=${TEST_ARTIFACTS_PATH}/coverage
           mkdir -p ${cov_dir}/codecov ${cov_dir}/raw
-          go test -shuffle=on -coverpkg=./... -coverprofile=${cov_dir}/raw/coverage.out -covermode=count ./...
-          grep -hv -e "testutils" ${cov_dir}/raw/coverage.out > ${cov_dir}/codecov/coverage.out.codecov
+
+          # Print executed commands to ease debugging
+          set -x
+
+          go test -shuffle=on -coverpkg=./... -coverprofile=${cov_dir}/raw/coverage.out -covermode=set ./...
+
+          # Filter out the testutils and testsdetection packages from the coverage report
+          grep -hv -e "testutils" -e "testsdetection" ${cov_dir}/raw/coverage.out > ${cov_dir}/codecov/coverage.out.codecov
           gocov convert ${cov_dir}/codecov/coverage.out.codecov | gocov-xml > ${cov_dir}/coverage.xml
 
-          SAFE_ID=$(echo "${{ matrix.subproject }}-${{ matrix.os }}" | tr '/' '_')
-          echo "SAFE_ID=$SAFE_ID" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Run tests (with race detector)
-        if: matrix.test == 'race' && runner.os != 'macOS'
-        env:
-          GO_TESTS_TIMEOUT: 35m
-        working-directory: ${{ matrix.subproject }}
-        run: |
-          set -euo pipefail
-          go test -json -timeout ${GO_TESTS_TIMEOUT} -race ./... | \
-            gotestfmt --logfile "${INSIGHTS_TEST_ARTIFACTS_PATH}/gotestfmt.race.log"
-        shell: bash
-
-      - name: Run tests (with unformatted race detector)
-        if: matrix.test == 'race' && runner.os == 'macOS'
-        env:
-          GO_TESTS_TIMEOUT: 35m
-        working-directory: ${{ matrix.subproject }}
-        run: |
-          set -euo pipefail
-          go test -json -timeout ${GO_TESTS_TIMEOUT} -race ./...
-        shell: bash
-
-      - name: Upload test coverage artifact
-        if: matrix.test == 'coverage'
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-${{ env.SAFE_ID }}
-          path: ${{ matrix.subproject }}/coverage/coverage.xml
-
       - name: Upload test artifacts
-        if: always() && matrix.test == 'race' && runner.os != 'macOS'
         uses: actions/upload-artifact@v4
         with:
-          name: insights-${{ github.job }}-${{ matrix.test }}-${{ matrix.subproject }}-${{ matrix.os }}-artifacts-${{ github.run_attempt }}
-          path: ${{ env.INSIGHTS_TEST_ARTIFACTS_PATH }}
+          name: insights-${{ github.job }}-${{ matrix.module }}-${{ matrix.os }}-artifacts-${{ github.run_attempt }}
+          path: ${{ env.TEST_ARTIFACTS_PATH }}
 
-  codecoverage:
-    name: "Combine and upload code coverage"
-    needs: go-tests
+  process-coverage:
+    name: "Combine and process code coverage"
+    needs: go-coverage-tests
+    if: always() # Run this even if coverage tests fail
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -147,7 +175,7 @@ jobs:
       - name: Combine coverage reports
         shell: bash
         run: |
-          reportgenerator -reports:"./artifacts/*/coverage.xml" -targetdir:"./coverage" -reporttypes:Cobertura
+          reportgenerator -reports:"./artifacts/**/coverage.xml" -targetdir:"./coverage" -reporttypes:Cobertura
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -169,6 +169,7 @@ jobs:
       - name: Install dependencies
         run: |
           dotnet tool install -g dotnet-reportgenerator-globaltool
+          go install honnef.co/go/tools/cmd/staticcheck@latest
       - name: Down coverage artifacts
         uses: actions/download-artifact@v5
         with:
@@ -182,3 +183,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/Cobertura.xml
           disable_search: true
+      - name: TiCS quality gate
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: client
+          project: ubuntu-insights
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -54,24 +54,11 @@ jobs:
             subproject: server # server is only supported on Linux
             test: race
     steps:
-      - name: setup-go cache workaround #https://github.com/actions/setup-go/issues/424
-        shell: bash
-        run: echo "TAR_OPTIONS=--skip-old-files" >> $GITHUB_ENV
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - name: Prepare environment
+        uses: ./.github/actions/prepare-environment
         with:
-          go-version-file: go.work
-          cache-dependency-path: |
-            insights/go.sum
-            server/go.sum
-            common/go.sum
-            tools/go.sum
-
-      - name: Install dependencies on Linux
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt update
-          sudo apt install -y ${{ env.insights_apt_deps }}
+          apt-dependencies: ${{ env.insights_apt_deps }}
 
       - name: Install gotestfmt and our wrapper script
         uses: canonical/desktop-engineering/gh-actions/go/gotestfmt@main

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -6,6 +6,9 @@ on:
     tags:
       - "*"
   pull_request:
+  schedule:
+    # Weekly scan
+    - cron: "15 4 * * 1"
 
 env:
   DEBIAN_FRONTEND: noninteractive
@@ -183,11 +186,20 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/Cobertura.xml
           disable_search: true
-      - name: TiCS quality gate
+      - name: "TiCS: quality gate"
         if: ${{ github.event_name == 'pull_request' }}
         uses: tiobe/tics-github-action@v3
         with:
           mode: client
+          project: ubuntu-insights
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true
+      - name: "TiCS: QServer"
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' }} # Only push to main and scheduled
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
           project: ubuntu-insights
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -31,7 +31,9 @@ defaults:
 
 jobs:
   plan:
-    name: Create test plan # Dynamic matrix generation for subsequent jobs
+    # Dynamic matrix generation for subsequent jobs.
+    # The `env` context is not available in `strategy`, but `needs` is: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability.
+    name: Create test plan
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -146,7 +146,8 @@ jobs:
           # Print executed commands to ease debugging
           set -x
 
-          go test -shuffle=on -coverpkg=./... -coverprofile=${cov_dir}/raw/coverage.out -covermode=set ./...
+          go test -json -shuffle=on -coverpkg=./... -coverprofile=${cov_dir}/raw/coverage.out -covermode=set ./... \
+            | gotestfmt --logfile "${TEST_ARTIFACTS_PATH}/gotestfmt.coverage.log"
 
           # Filter out the testutils and testsdetection packages from the coverage report
           grep -hv -e "testutils" -e "testsdetection" ${cov_dir}/raw/coverage.out > ${cov_dir}/codecov/coverage.out.codecov

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -76,6 +76,13 @@ jobs:
       - name: Install gotestfmt and our wrapper script
         uses: canonical/desktop-engineering/gh-actions/go/gotestfmt@main
 
+      - name: Install coverage test dependencies
+        shell: bash
+        if: matrix.test == 'coverage'
+        run: |
+          go install github.com/AlekSi/gocov-xml@latest
+          go install github.com/axw/gocov/gocov@latest
+
       - name: Prepare tests artifacts path
         run: |
           set -euo pipefail
@@ -94,8 +101,12 @@ jobs:
 
           cov_dir=$(pwd)/coverage
           mkdir -p ${cov_dir}/codecov ${cov_dir}/raw
-          go test -shuffle=on -coverpkg=./... -coverprofile=${cov_dir}/raw/coverage.out -covermode=count ./... -tags=gowslmock
-          grep -hv -e "testutils" -e "pb.go:" ${cov_dir}/raw/coverage.out > ${cov_dir}/codecov/coverage.out.codecov
+          go test -shuffle=on -coverpkg=./... -coverprofile=${cov_dir}/raw/coverage.out -covermode=count ./...
+          grep -hv -e "testutils" ${cov_dir}/raw/coverage.out > ${cov_dir}/codecov/coverage.out.codecov
+          gocov convert ${cov_dir}/codecov/coverage.out.codecov | gocov-xml > ${cov_dir}/coverage.xml
+
+          SAFE_ID=$(echo "${{ matrix.subproject }}-${{ matrix.os }}" | tr '/' '_')
+          echo "SAFE_ID=$SAFE_ID" >> $GITHUB_ENV
         shell: bash
 
       - name: Run tests (with race detector)
@@ -119,12 +130,12 @@ jobs:
           go test -json -timeout ${GO_TESTS_TIMEOUT} -race ./...
         shell: bash
 
-      - name: Upload coverage to Codecov
+      - name: Upload test coverage artifact
         if: matrix.test == 'coverage'
-        uses: codecov/codecov-action@v5
+        uses: actions/upload-artifact@v4
         with:
-          directory: ${{ matrix.subproject }}/coverage/codecov
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-${{ env.SAFE_ID }}
+          path: ${{ matrix.subproject }}/coverage/coverage.xml
 
       - name: Upload test artifacts
         if: always() && matrix.test == 'race' && runner.os != 'macOS'
@@ -132,3 +143,26 @@ jobs:
         with:
           name: insights-${{ github.job }}-${{ matrix.test }}-${{ matrix.subproject }}-${{ matrix.os }}-artifacts-${{ github.run_attempt }}
           path: ${{ env.INSIGHTS_TEST_ARTIFACTS_PATH }}
+
+  codecoverage:
+    name: "Combine and upload code coverage"
+    needs: go-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install dependencies
+        run: |
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+      - name: Down coverage artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: ./artifacts/
+      - name: Combine coverage reports
+        shell: bash
+        run: |
+          reportgenerator -reports:"./artifacts/*/coverage.xml" -targetdir:"./coverage" -reporttypes:Cobertura
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/Cobertura.xml
+          disable_search: true


### PR DESCRIPTION
This PR refactors the "QA & sanity checks" workflow and adds TiCS integration.

The integration of TiCS surfaced some challenges with the prior setup for the QA workflow, as it requires you to upload coverage files from a very specific place. In the process of doing this, the workflow has been refactored with a number of additional fixes and changes. Since everything ties in with each other, it is a bit difficult to split up this PR

- Add new scheduled trigger
  - 4:15 UTC weekly on Monday to try and avoid heavy hours
    - We don't really need a daily since we also trigger on push to main. 
- Create a new `process-coverage` job
  - Processes the coverage outputs from the coverage tests, combining and converting them to Cobertura
  - Upload all coverage results to Codecov in one go
  - Trigger TiCS depending on the workflow event trigger
    - Client mode (quality gate) if PR
    - QServer mode if push to main or scheduled 
      - Though the push is only triggered by tags and push-to-main events, the conditional is explicit in case it is ever changed.
- Split race and coverage tests into independent jobs
  - Though there is overlap in setup for the two tasks, by splitting we can allow for the coverage processing job to not need to potentially wait for race tests to complete
 - Coverage only changes:
   - Filter out the "testdetection" module from coverage outputs
   - Remove the filtering out of the `pb.go` file since we don't have that 
 - Improved `gotestfmt` integration
   - Following far too much investigation, a true workaround has been implemented for the issue where we had a large string of broken pipe errors coupled with a cryptic panic from `gotestfmt`. The fixes have been merged here in our upstream wrapper: https://github.com/canonical/desktop-engineering/pull/
        - Re-enable `gotestfmt` integration on macOS runners for Go `-race` tests
        - Add `gotestfmt` integration for coverage tests
  - Fixed test artifact outputs on Windows
  	-  Though `mktemp` can run on Windows, it behaves as if on a Unix system. Thus, the outputs are a little wonky on Windows, resulting in the artifact uploader being unable to pick up the artifacts. This triggered a warning before. 
  	- Since the uniqueness of `mktemp` isn't really necessary for our use case, and since its behavior differs not only between Unix and Windows, but between Linux, Windows, *and* Darwin, it was simpler to just replace it with a simplified method.
 - Go: Sanity
   - Upstream fix for warning about `jq` already being installed on macOS runners https://github.com/canonical/desktop-engineering/pull/74 
 - General refactoring and cleanup
   - Default the shell to `bash` always
   - Use a dynamic planning job to create the matrices used for the sanity and test jobs
   - Refactor out the setup of full repository dependencies to a separate action (implemented for lrc-qa as well) 
   
  ---
  [UDENG-7552](https://warthogs.atlassian.net/browse/UDENG-7552)
  [UDENG-7258](https://warthogs.atlassian.net/browse/UDENG-7258)

[UDENG-7552]: https://warthogs.atlassian.net/browse/UDENG-7552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ