### PR TITLE
maint(insights): New changelog entry for 0.6.2

### DIFF
--- a/insights/debian/changelog
+++ b/insights/debian/changelog
@@ -1,3 +1,10 @@
+ubuntu-insights (0.6.2) questing; urgency=medium
+
+  * Fix broken test files
+  * Go dependency updates
+
+ -- Kat Kuo <kat.kuo@canonical.com>  Thu, 28 Aug 2025 11:51:31 -0400
+
 ubuntu-insights (0.6.1) questing; urgency=medium
 
   * New upstream release (LP: #2121454)

--- a/insights/go.mod
+++ b/insights/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
 	github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19
-	github.com/ubuntu/ubuntu-insights/common v0.6.1
+	github.com/ubuntu/ubuntu-insights/common v0.6.2
 	golang.org/x/text v0.28.0
 	gopkg.in/ini.v1 v1.67.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/insights/go.sum
+++ b/insights/go.sum
@@ -54,8 +54,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19 h1:IP8p46//e//o0KPZdAzl+WF1DdRKHXfkbB+sQDCAlkw=
 github.com/ubuntu/decorate v0.0.0-20250213124239-8228e241ee19/go.mod h1:PUpwIgUuCQyuCz/gwiq6WYbo7IvtXXd8JqL01ez+jZE=
-github.com/ubuntu/ubuntu-insights/common v0.6.1 h1:fAx8j3H21ofOjyaqz//7hBvpAPpfhWrzTcL4pcYj0Gc=
-github.com/ubuntu/ubuntu-insights/common v0.6.1/go.mod h1:M7p8z4zy0p1NKUBhj7g+2IA1vVXki6tY5z541JOLQJ0=
+github.com/ubuntu/ubuntu-insights/common v0.6.2 h1:gFB82ha3rNKmQzVZ2kjmE1pBVrHYhx6SDq7OD05umRw=
+github.com/ubuntu/ubuntu-insights/common v0.6.2/go.mod h1:fcUz1+IfhnTcuGkh6CPV97QxBDpLrLQPtEZGUW4AmCo=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=

--- a/server/go.mod
+++ b/server/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.38.0
-	github.com/ubuntu/ubuntu-insights/common v0.6.1
+	github.com/ubuntu/ubuntu-insights/common v0.6.2
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/server/go.sum
+++ b/server/go.sum
@@ -265,8 +265,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
-github.com/ubuntu/ubuntu-insights/common v0.6.1 h1:fAx8j3H21ofOjyaqz//7hBvpAPpfhWrzTcL4pcYj0Gc=
-github.com/ubuntu/ubuntu-insights/common v0.6.1/go.mod h1:M7p8z4zy0p1NKUBhj7g+2IA1vVXki6tY5z541JOLQJ0=
+github.com/ubuntu/ubuntu-insights/common v0.6.2 h1:gFB82ha3rNKmQzVZ2kjmE1pBVrHYhx6SDq7OD05umRw=
+github.com/ubuntu/ubuntu-insights/common v0.6.2/go.mod h1:fcUz1+IfhnTcuGkh6CPV97QxBDpLrLQPtEZGUW4AmCo=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=


### PR DESCRIPTION
Release 0.6.2 is mostly resolving an issue with a broken patch downstream as well as a few new Go dependency updates. 

This PR includes a bump for the common module version, which itself had dependency updates.