### PR TITLE
fix(insights): Change section of the main package to utils

### DIFF
--- a/insights/debian/control
+++ b/insights/debian/control
@@ -1,5 +1,5 @@
 Source: ubuntu-insights
-Section: golang
+Section: utils
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Rules-Requires-Root: no


### PR DESCRIPTION
This PR changes the section of the main `ubuntu-insights` package to `utils` from `golang`.