### PR TITLE
ci: Disable TiCS client mode and filter for only ubuntu-24.04 coverage 

### DIFF
--- a/.github/actions/prepare-environment/action.yaml
+++ b/.github/actions/prepare-environment/action.yaml
@@ -8,6 +8,9 @@ inputs:
   apt-dependencies:
     description: A space-separated list of apt dependencies to install (Ignored if not using a Linux runner).
     default: ""
+  download-go-deps:
+    description: Whether to pre-download Go module dependencies for all modules in the repository.
+    default: "false"
 
 runs:
   using: "composite"
@@ -29,3 +32,15 @@ runs:
         set -e
         sudo apt-get update
         sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ${{ inputs.apt-dependencies }}
+
+    - name: Download Go module dependencies
+      if: inputs.download-go-deps == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd ${{ inputs.working-directory }}
+        find . -type f -name 'go.mod' -print0 | while IFS= read -r -d '' file; do
+          dir=$(dirname "$file")
+          echo "Downloading Go module dependencies in $dir"
+          (cd "$dir" && go mod download)
+        done

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -203,20 +203,13 @@ jobs:
         uses: ./.github/actions/prepare-environment
         with:
           apt-dependencies: ${{ env.INSIGHTS_APT_DEPS }}
+          download-go-deps: "true"
 
       - name: Install TiCS dependencies
         if: ${{ steps.tics-condition.outputs.tics_mode != '' }}
         run: |
           set -euo pipefail
           go install honnef.co/go/tools/cmd/staticcheck@latest
-
-          modules=("insights" "common" "server")
-          for module in "${modules[@]}"; do
-            echo "Downloading dependencies for module: $module"
-            pushd "$module" > /dev/null
-            go mod download
-            popd > /dev/null
-          done
 
       - name: Process coverage reports
         if: ${{ steps.tics-condition.outputs.tics_mode != '' }}


### PR DESCRIPTION
As discussed, due to the limitations in how TiCS presents issues in client mode being problematic for OSS, we now only use the qserver mode of TiCS. To avoid duplicate work, excessive use of the runners, and also avoid the "skipped job" annotation on every PR, everything is still in the same job. While the TiCS items could be split into their own workflow, the steps to generate the coverage data aren't trivial enough to justify running it twice, given we still want the QA workflow to run on push to main. Additionally, while it is possible to have a workflow download artifacts from an independent workflow, this can be rather fragile.

In addition, we now filter coverage reports fed to TiCS such that only reports generated by the Ubuntu-24.04 run are used. This is necessary since TiCS does not support multiple coverage lines for the same file. If there are multiple coverage lines that match a particular file, it will error and not have any coverage stats for that file at all.

This PR also adds a step that forces `go download` for each of the modules so that dependencies are downloaded, not just cached when we enter TiCS.