### PR TITLE
ci: Cleanup annotations in QA workflow

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -249,3 +249,4 @@ jobs:
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=GoProjects
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
+          postAnnotations: false # Often not useful due to just false positives hitting the GitHub 10 annotations limit


### PR DESCRIPTION
This PR aims to clean up the annotations in the QA workflow, helping reduce notification fatigue and clearing out irrelevant annotations.

These are the annotations on the summary page of a [recent run](https://github.com/ubuntu/ubuntu-insights/actions/runs/17679179093) triggered by a push to main:
<img width="1588" height="980" alt="image" src="https://github.com/user-attachments/assets/bf66af89-df07-4099-bc7d-2635b00a5c94" />

The TiCS annotations are all false positives or irrelevant, with no actions on our front that could really resolve them. There are so many that it hits GitHub's 10 error annotations per step limit. There is a way for action developers to get past this limit, but it appears the TiCS developers aren't using it: https://github.com/orgs/community/discussions/26680. Either way, it is unclear how useful the annotations would be with that many anyway. Thus, given how they aren't useful, it is better to just disable the annotations.

---
[UDENG-7908](https://warthogs.atlassian.net/browse/UDENG-7908)

[UDENG-7908]: https://warthogs.atlassian.net/browse/UDENG-7908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ