### PR TITLE
ci: Update GH runner images

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -19,7 +19,7 @@ env:
   # The "server" module only supports ubuntu.
   RAW_MATRIX: |
     {
-      "os": ["ubuntu-24.04", "windows-2022", "macos-13", "macos-14"],
+      "os": ["ubuntu-24.04", "windows-2025", "macos-15-intel", "macos-15"],
       "module": ["insights", "common"],
       "include": [
         {"os": "ubuntu-24.04", "module": "server"}


### PR DESCRIPTION
Updates the QA workflow GH runners from `windows-2022` to `windows-2025`, `macos-13` to `macos-15-intel`, and `macos-14` to `macos-15`. 

The `macos-13` GitHub runner image is now deprecated, so we are required to move to something else. The other changes are just to keep things updated.