### PR TITLE
fix(sever/ingest): Sanitize null characters from reports

### DIFF
--- a/server/cmd/ingest-service/integration-tests/ingest_test.go
+++ b/server/cmd/ingest-service/integration-tests/ingest_test.go
@@ -140,6 +140,13 @@ func TestIngestService(t *testing.T) {
 				{app: "ubuntu-report/distribution/desktop/version", reportType: invalidJSON, count: 1},
 			},
 		},
+		"Reports with null escape characters are sanitized": {
+			validApps: []string{"linux"},
+			preReports: []reports{
+				{app: "linux", reportType: validV1WithNullEscape, count: 2},
+				{app: "linux", reportType: invalidWithNullEscape, count: 1},
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -414,6 +421,8 @@ const (
 	invalidV1ExtraFields
 	invalidOptOut
 	ubuntuReport
+	validV1WithNullEscape
+	invalidWithNullEscape
 )
 
 func makeReport(t *testing.T, reportType report, count int, reportDir string, atomicWrite bool) {
@@ -1040,6 +1049,25 @@ this is invalid JSON`
     }
   }
 }`
+	case validV1WithNullEscape:
+		rep = `
+{
+    "insightsVersion": "0.0.1~ppa5",
+    "collectionTime": 1747752692,
+    "systemInfo": {
+        "hardware": {
+            "product": {
+                "name": "surrogate \uD800 test"
+            }
+        },
+        "software": {
+            "description": "value with surrogate \uDFFF trailing",
+            "nullByte": "embedded \u0000 null"
+        }
+    }
+}`
+	case invalidWithNullEscape:
+		rep = `{"iam": "invalid \uD800 data with \u0000 null"}`
 	}
 
 	// Write the report to a file, with uuid name and .json extension

--- a/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_null_escape_characters_are_sanitized
+++ b/server/cmd/ingest-service/integration-tests/testdata/TestIngestService/golden/reports_with_null_escape_characters_are_sanitized
@@ -1,0 +1,46 @@
+{
+  "RemainingFiles": {},
+  "ReportsCount": {
+    "darwin": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
+    "linux": {
+      "TotalReports": 2,
+      "OptOutReports": 0,
+      "OptInReports": 2
+    },
+    "ubuntu_desktop_provision": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
+    "ubuntu_release_upgrader": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
+    "ubuntu_report": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
+    "windows": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    },
+    "wsl_setup": {
+      "TotalReports": 0,
+      "OptOutReports": 0,
+      "OptInReports": 0
+    }
+  },
+  "InvalidReports": [
+    {
+      "AppName": "linux",
+      "RawReport": "1146506187"
+    }
+  ]
+}

--- a/server/internal/ingest/processor/processor.go
+++ b/server/internal/ingest/processor/processor.go
@@ -3,6 +3,7 @@
 package processor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -359,6 +360,13 @@ func getReportID(file string) string {
 	return reportID
 }
 
+// sanitizeInvalidUnicodeEscapes replaces JSON Unicode escape sequences that PostgreSQL cannot store
+// (the null character U+0000) with the Unicode replacement
+// character escape (\ufffd) to prevent PostgreSQL SQLSTATE 22P05 errors.
+func sanitizeInvalidUnicodeEscapes(data []byte) []byte {
+	return bytes.ReplaceAll(data, []byte(`\u0000`), []byte(`\ufffd`))
+}
+
 // decodeFile reads a JSON file, unmarshals, and decodes it into the specified target model type.
 // It returns the target model or an error if the file is invalid or does not match the expected structure.
 func decodeFile[T models.TargetModels](file string) (*T, error) {
@@ -366,6 +374,8 @@ func decodeFile[T models.TargetModels](file string) (*T, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	data = sanitizeInvalidUnicodeEscapes(data)
 
 	var jsonData map[string]any
 	if err = json.Unmarshal(data, &jsonData); err != nil {
@@ -414,6 +424,8 @@ func (p Processor) uploadInvalid(ctx context.Context, file, id, app string) (boo
 	if err != nil {
 		return false, fmt.Errorf("failed to re-read invalid file %q: %v", file, err)
 	}
+
+	data = sanitizeInvalidUnicodeEscapes(data)
 
 	if len(data) == 0 || strings.TrimSpace(string(data)) == "" {
 		slog.Info("Skipping upload of empty invalid file", "file", file)

--- a/server/internal/ingest/processor/processor_test.go
+++ b/server/internal/ingest/processor/processor_test.go
@@ -184,6 +184,11 @@ func TestProcessFiles(t *testing.T) {
 
 			wantErr: context.Canceled,
 		},
+
+		"Reports with null escape characters are sanitized": {
+			app:   "NullEscapeCleaning",
+			delay: 5 * time.Second,
+		},
 	}
 
 	for name, tc := range tests {

--- a/server/internal/ingest/processor/testdata/TestProcessFiles/golden/reports_with_null_escape_characters_are_sanitized
+++ b/server/internal/ingest/processor/testdata/TestProcessFiles/golden/reports_with_null_escape_characters_are_sanitized
@@ -1,0 +1,33 @@
+{
+  "RemainingFiles": {},
+  "UploadedFiles": {
+    "NullEscapeCleaning": [
+      {
+        "insightsVersion": "0.0.1~ppa5",
+        "collectionTime": 1747752692,
+        "systemInfo": {
+          "hardware": {
+            "product": {
+              "name": "surrogate � test ぁ"
+            }
+          },
+          "software": {
+            "description": "value with surrogate � trailing",
+            "nullByte": "embedded � null"
+          }
+        }
+      }
+    ]
+  },
+  "UploadedLegacyFiles": null,
+  "InvalidReports": {
+    "NullEscapeCleaning": [
+      "1848426824"
+    ]
+  },
+  "ReferenceHashes": {
+    "invalid_with_surrogate.json": "888268637",
+    "valid_with_surrogate.json": "2766003619"
+  },
+  "Metrics": "# HELP ingest_processor_cache_size Current number of reports in the cache for a given app, indicating the number of pending reports.\n# TYPE ingest_processor_cache_size gauge\ningest_processor_cache_size{app=\"NullEscapeCleaning\"} 2\n# HELP ingest_processor_cache_size_bytes Current size of the reports cache for a given app in bytes, indicating the size of pending reports.\n# TYPE ingest_processor_cache_size_bytes gauge\ningest_processor_cache_size_bytes{app=\"NullEscapeCleaning\"} 428\n# HELP ingest_processor_files_processed_total Total number of files processed by the processor.\n# TYPE ingest_processor_files_processed_total counter\ningest_processor_files_processed_total{app=\"NullEscapeCleaning\",result=\"success\"} 2\n"
+}

--- a/server/internal/ingest/processor/testdata/fixtures/NullEscapeCleaning/invalid_with_surrogate.json
+++ b/server/internal/ingest/processor/testdata/fixtures/NullEscapeCleaning/invalid_with_surrogate.json
@@ -1,0 +1,3 @@
+{
+    "iam": "invalid \uD800 data with \u0000 null"
+}

--- a/server/internal/ingest/processor/testdata/fixtures/NullEscapeCleaning/valid_with_surrogate.json
+++ b/server/internal/ingest/processor/testdata/fixtures/NullEscapeCleaning/valid_with_surrogate.json
@@ -1,0 +1,15 @@
+{
+    "insightsVersion": "0.0.1~ppa5",
+    "collectionTime": 1747752692,
+    "systemInfo": {
+        "hardware": {
+            "product": {
+                "name": "surrogate \uD800 test \u3041"
+            }
+        },
+        "software": {
+            "description": "value with surrogate \uDFFF trailing",
+            "nullByte": "embedded \u0000 null"
+        }
+    }
+}


### PR DESCRIPTION
Null characters (U+0000) that end up in reports currently cause issues when we try to ingest them, as PostgreSQL does not accept them and will error with SQLSTATE 22P05. Thus, we need to explicitly sanitize the reports to remove them.

Here we do just that, for both standard operations and for invalid reports, replacing null characters with the Unicode replacement character �.

---
[UDENG-9471](https://warthogs.atlassian.net/browse/UDENG-9471)

[UDENG-9471]: https://warthogs.atlassian.net/browse/UDENG-9471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ