### PR TITLE
feat: Implement an example snapcraft.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ ingest-service
 !ingest-service/
 web-service
 !web-service/
+
+# Snap build artifacts
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,85 @@
+name: ubuntu-insights
+version: "1.0.0"
+summary: A transparent tool to collect and share anonymous insights about your system
+description: |
+  A transparent tool to collect and share anonymous insights about your system.
+  .
+  If consent is given, this tool collects non-personally identifying hardware, software, and platform information, and shares it with the Ubuntu Development team.
+  The information collected can't be used to identify a single machine. All reports are cached on the local machine and can be reviewed before and after uploading.
+  More details on https://github.com/ubuntu/ubuntu-insights
+grade: devel
+confinement: strict
+base: core24
+source-code: https://github.com/ubuntu/ubuntu-insights
+license: GPL-3.0
+
+apps:
+  ubuntu-insights:
+    command: bin/ubuntu-insights
+    completer: bash-completion.sh
+    plugs:
+      - hardware-observe
+      - wayland
+      - x11
+      - network # Needed for uploading
+      # - ubuntu-pro-control # Doesn't work atm, needs we need to use the dbus interface directly.
+      - dot-config-ubuntu-insights # Default config location
+      - dot-cache-ubuntu-insights # Default cache location
+      - block-devices # Required to see encrypted partitions. `dm-crypt` also works.
+      - read-all-home # Allow attachment of source-metrics from home
+
+parts:
+  cli:
+    source: .
+    plugin: nil
+    build-snaps:
+      - go/1.25/stable
+    build-packages:
+      - libwayland-dev
+    build-environment:
+      - GOTOOLCHAIN: local
+    override-build: |
+      go build \
+        -ldflags=-X=github.com/ubuntu/ubuntu-insights/insights/internal/constants.Version=snap-${CRAFT_PROJECT_VERSION} \
+        -o ${SNAPCRAFT_PART_INSTALL}/bin/ubuntu-insights \
+        ./insights/cmd/insights
+
+      go generate ./insights/cmd/insights/main.go
+
+      chmod a+r insights/generated/usr/share/bash-completion/completions/ubuntu-insights 
+      cp insights/generated/usr/share/bash-completion/completions/ubuntu-insights ${SNAPCRAFT_PART_INSTALL}/bash-completion.sh
+    stage-packages:
+      - libwayland-client0
+      - x11-xserver-utils
+    stage:
+      - bin/ubuntu-insights
+      - bash-completion.sh
+      - usr/lib/*/libwayland-client.so.*
+      - usr/lib/*/libXau.so.*
+      - usr/lib/*/libXdmcp.so.*
+      - usr/lib/*/libXext.so.*
+      - usr/lib/*/libXrender.so.*
+      - usr/lib/*/libxcb.so.*
+      - usr/lib/*/libX11.so.*
+      - usr/lib/*/libXrandr.so.*
+      - usr/bin/xrandr
+
+  nano:
+    plugin: nil
+    stage-packages:
+      - nano
+    stage:
+      - usr/bin/nano
+
+plugs:
+  dot-config-ubuntu-insights:
+    interface: personal-files
+    read:
+      - $HOME/.config/ubuntu-insights
+  dot-cache-ubuntu-insights:
+    interface: personal-files
+    write:
+      - $HOME/.cache/ubuntu-insights
+  read-all-home:
+    interface: home
+    read: all


### PR DESCRIPTION
This PR implements an example `snapcraft.yaml` file with strict confinement. This was tested to work with both Wayland and X11 hosts.

Note that with its current state, there are a few things that don't work at the moment.

1. Getting the distro and distro version

Staging `lsb_release` into the snap results in us reading the snap base information instead of the host. We need to introduce new behavior into `ubuntu-insights` to default to trying to directly parse `/etc/lsb-release` for this information. Note that in snaps, `/etc/lsb-release` is from the host, while `/etc/os-release` is the snap base info.

2. Getting the pro-attach state

Presently, Ubuntu Insights calls `pro status` to try and get the attach state. The pro client doesn't work very well when staged into the snap, so it'd be best to rework the Ubuntu Insights client to instead get this information from the dbus.

---
[UDENG-8609](https://warthogs.atlassian.net/browse/UDENG-8609)

[UDENG-8609]: https://warthogs.atlassian.net/browse/UDENG-8609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ