### PR TITLE
deps(go.work): Bump go toolchain to 1.25.10

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.25.0
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 use (
 	./common


### PR DESCRIPTION
Fixes a few security issues.