### PR TITLE
maint(.g): Add Copilot instructions files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+# Copilot Cloud Agent Onboarding
+
+## What This Repository Is
+
+- `ubuntu-insights` is a Go monorepo for Ubuntu telemetry collection and processing.
+- It has two product areas:
+  - Client side (`insights`): CLI (`ubuntu-insights`), Go API, C bindings (`libinsights`), Debian packaging.
+  - Server side (`server`): `web-service` (HTTP intake) and `ingest-service` (validation + DB ingest).
+- Shared code lives in `common`.
+
+## Stack And Runtime
+
+- **Language**: Go. ALWAYS check the root [go.work](../go.work) and module-level `go.mod` files for the exact Go and toolchain versions. Do not assume hardcoded Go versions.
+- **C/CGo bindings**: Found under [insights/C/](../insights/C).
+- **Debian packaging**: Found under [insights/debian/](../insights/debian).
+- **CI Environments**: Linux, macOS, and Windows for Go checks; Debian packaging and autopkgtest run on Ubuntu.
+
+## Repository Layout & Core Paths
+
+- [go.work](../go.work): workspace root for the 4 modules:
+  - [common/](../common/): shared helpers (`cli`, `fileutils`, test utilities including golden file helpers).
+  - [insights/](../insights/): client implementation, Collectors, Consent logic, Uploader, and C bindings.
+  - [server/](../server/): intake web-service and ingest pipeline.
+  - [tools/](../tools/): development/utility CLI and tools.
+
+## Developer Workflows
+
+The repository maintains specialized on-request Agent Skills for specific domains. Refer to these skills rather than hardcoding complex paths or execution steps:
+
+- **Go Bootstrapping, Building, Testing, & Linting**: See the `go-development` skill for commands to fetch dependencies, build components, run fast unit tests, run race-detector checks (`-race`), and run golangci-lint.
+- **C/CGo and C Bindings Development**: See the `cgo-bindings` skill for compiler requirements, manual generating (`go generate ./insights/C/...`), formatting, and C integration checks.
+- **Debian Package Building & Autopkgtests**: See the `debian-packaging` skill for isolated packaging via `sbuild`, local package building with debuild, and verifying dbus/systemd smoke tests.
+
+Prefer utilizing the workspace's pre-configured VS Code tasks (such as `Go: Test Module(s)` or `Go: golangci-lint Module(s)`) via the tasks runner whenever possible.
+
+## Key Constraints & Validation Rules
+
+- **Strict Error and Code Style**: Automated instructions in `.github/instructions/` (e.g., `go-style.instructions.md`, `go-error-handling.instructions.md`, `go-tests.instructions.md`, `go-export-pattern.instructions.md`) are automatically applied using file-matching rules. Follow them exactly when editing code.
+- **Systemd User Units**: If editing units or timers under [insights/autostart/systemd/](../insights/autostart/systemd), the systemd rules in `.github/instructions/systemd.instructions.md` apply automatically. You must run:
+  ```bash
+  systemd-analyze --user verify ./insights/autostart/systemd/*
+  ```
+- **Golden Files**: If updating golden test outputs under unit/integration tests, trigger standard tests with `TESTS_UPDATE_GOLDEN=yes` (or use the VS Code task `Go: Update Golden Files`) and commit the resulting changes together.
+- **Docker Requirement**: The server integration tests utilize `testcontainers-go`; ensure a Docker-compatible runtime is active before executing them.

--- a/.github/instructions/go-error-handling.instructions.md
+++ b/.github/instructions/go-error-handling.instructions.md
@@ -1,0 +1,45 @@
+---
+description: "Use when creating or editing Go error handling. Covers repository guidance for sentinel errors, `%w` vs `%v`, `errors.Is`/`errors.As`, and when to use `errors.Join`."
+applyTo: "**/*.go"
+---
+
+# Go Error Handling Conventions
+
+- Prefer `errors.New` for static sentinel errors and declare them as `var ErrSomething = errors.New("...")`.
+- Use `%w` only when callers are expected to match the underlying error later with `errors.Is` or `errors.As`.
+- If the underlying error is only being included for human-readable context, use `%v` instead of `%w`.
+- Do not mechanically wrap every returned error. Wrapping is part of the API surface because it preserves the cause chain.
+- Prefer one meaningful layer of context at the abstraction boundary that changes what the operation means to the caller.
+- When a caller needs to match a domain-specific condition and still retain extra detail, prefer `errors.Join` with a sentinel error.
+- Use lowercase error messages without trailing punctuation.
+- Avoid exporting foreign implementation details by default. Expose them only when callers have a concrete need to branch on them.
+
+## Preferred Patterns
+
+```go
+var ErrConsentFileNotFound = errors.New("consent file not found")
+
+func loadConsent(path string) error {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        if errors.Is(err, os.ErrNotExist) {
+            return errors.Join(ErrConsentFileNotFound, err)
+        }
+        return fmt.Errorf("failed to read consent file: %v", err)
+    }
+
+    _ = data
+    return nil
+}
+```
+
+```go
+func decodeConfig(path string) error {
+    if err := readConfig(path); err != nil {
+        return fmt.Errorf("invalid configuration file: %w", err)
+    }
+    return nil
+}
+```
+
+Use `%w` in the second example only because callers legitimately need to inspect the underlying parse error later and act upon it differently from other errors.

--- a/.github/instructions/go-export-pattern.instructions.md
+++ b/.github/instructions/go-export-pattern.instructions.md
@@ -1,0 +1,60 @@
+---
+description: "Use when creating or editing Go export_test wrappers. Covers the repository export pattern for exposing internal symbols to tests without changing production APIs."
+applyTo: "**/export_test.go"
+---
+
+# Go Export Pattern For Tests
+
+Use `export_test.go` to expose internals only for tests in the same package.
+
+- Keep these files test-only bridges: no production logic, no runtime behavior changes.
+- Prefer simple exported wrappers around private members:
+  - Type aliases for private types where useful (`type AppConfig = appConfig`).
+  - Getter methods to expose private fields needed by tests.
+  - Setter/helper methods to configure app/command state for tests.
+  - Option constructors that inject test doubles when needed.
+- Keep helper setup deterministic and test-friendly:
+  - Use `t.Helper()` in setup helpers.
+  - Use `t.TempDir()` for temporary files.
+  - Use `require.NoError` for setup failures with clear `Setup:`-prefixed messages.
+- Preserve encapsulation where possible:
+  - If returning internal maps/slices/pointers, guard with existing locks and avoid unnecessary mutation in tests.
+- Keep naming explicit (`NewForTests`, `GenerateTestConfig`, `SetArgs`, `AllowSet`) and place wrappers near the internals they expose.
+
+## Scope Notes
+
+- This pattern is for test support only and must not be referenced by non-test production code.
+- Prefer this pattern over widening production visibility solely for tests.
+
+## Companion Test Code Outside export_test.go
+
+In regular test files (`*_test.go`) that pair with this pattern:
+
+- Consume helpers exposed by `export_test.go` instead of changing production visibility.
+- Build tests around explicit setup helpers (`NewForTests`, `GenerateTestConfig`, `GenerateTestAllowlist`) when available.
+- Keep setup and assertion logic in `*_test.go`; keep `export_test.go` focused on bridging internals.
+- Prefer package-internal tests (`package samepkg`) when you need access via these exported wrappers.
+- Avoid duplicating wrapper logic in `*_test.go`; add missing wrappers in `export_test.go` instead.
+
+## Do And Don’t
+
+```go
+// DO: keep export_test.go as a narrow bridge for tests.
+func (a *App) SetArgs(args ...string) {
+  a.cmd.SetArgs(args)
+}
+
+// DON'T: move test assertions or business logic into export_test.go.
+func (a *App) VerifyBehaviorInTests(t *testing.T) {
+  // avoid assertion logic here
+}
+```
+
+```go
+// DO in *_test.go: use exported test helpers from export_test.go.
+func TestRun(t *testing.T) {
+  app := NewForTests(t, nil, allowlistPath)
+  app.SetArgs("--json-logs")
+  // assertions belong here
+}
+```

--- a/.github/instructions/go-style.instructions.md
+++ b/.github/instructions/go-style.instructions.md
@@ -1,0 +1,38 @@
+---
+description: "Use when creating or editing Go production code. Covers repository Go style for naming, control flow, dependency setup, and keeping logic explicit and easy to maintain."
+applyTo: "**/*.go"
+---
+
+# Go Style Conventions
+
+- Prefer small, explicit functions over clever abstractions.
+- Validate required inputs and dependencies early, then return immediately on invalid state.
+- Strive for making invalid states non-representable to avoid spreading validation everywhere.
+- Keep control flow flat: prefer guard clauses and early returns over nested `else` blocks.
+- Keep exported APIs narrow. Do not widen visibility just to satisfy tests; use the existing `export_test.go` pattern instead.
+- Prefer descriptive names over abbreviations, except for well-known initialisms (`URL`, `JSON`, `HTTP`) and conventional short receiver names.
+- Keep constructors and options pragmatic:
+  - Use a constructor when required dependencies or invariants must be enforced.
+  - Do not introduce option plumbing for a type that can be configured more clearly with direct fields or simple arguments.
+- Prefer package-level sentinel errors only for conditions callers need to branch on.
+- Keep comments for non-obvious invariants, edge cases, or intent; avoid comments that restate the code.
+- Avoid unnecessary helper extraction. A short local block is usually better than a helper that obscures the main path.
+- At a given layer, either log an error or return it with context. Avoid duplicating the same failure message in both places unless each layer adds distinct operational value.
+
+## Quick Pattern
+
+```go
+func NewProcessor(reportsDir string, uploader Uploader) (*Processor, error) {
+    if reportsDir == "" {
+        return nil, errors.New("reportsDir must be set")
+    }
+    if uploader == nil {
+        return nil, errors.New("uploader must be set")
+    }
+
+    return &Processor{
+        reportsDir: reportsDir,
+        uploader:   uploader,
+    }, nil
+}
+```

--- a/.github/instructions/go-tests.instructions.md
+++ b/.github/instructions/go-tests.instructions.md
@@ -1,0 +1,35 @@
+---
+description: "Use when creating or editing Go tests, including integration test wrappers and CGo test harness files. Covers table-driven map/dict test cases, subtest structure, golden file usage, and intentional golden updates."
+applyTo: "**/*_test.go,**/*integrationtests.go,**/libinsightstest.go"
+---
+
+# Go Test Conventions
+
+- Prefer table-driven tests keyed by name in a map/dict (`map[string]struct{...}`), iterated as `for name, tc := range tests { ... }`.
+- Use subtests for each case: `t.Run(name, func(t *testing.T) { ... })`.
+- Keep test cases deterministic and self-contained; avoid hidden shared mutable state between cases.
+- Use golden files when expected output is large, structured, or hard to maintain inline.
+- Use shared helpers from `common/testutils/golden.go`:
+  - `LoadWithUpdateFromGolden` for plaintext expectations.
+  - `LoadWithUpdateFromGoldenYAML` for structured/YAML expectations.
+- Update golden files intentionally with `TESTS_UPDATE_GOLDEN=yes`, then commit the updated golden artifacts in the same PR.
+- Prefer explicit, stable assertions over ad hoc string contains checks.
+
+## Quick Pattern
+
+```go
+tests := map[string]struct {
+    input string
+    want  string
+}{
+    "simple case": {input: "x", want: "y"},
+}
+
+for name, tc := range tests {
+    t.Run(name, func(t *testing.T) {
+        got := run(tc.input)
+        want := testutils.LoadWithUpdateFromGolden(t, got)
+        require.Equal(t, want, got)
+    })
+}
+```

--- a/.github/instructions/systemd.instructions.md
+++ b/.github/instructions/systemd.instructions.md
@@ -1,0 +1,21 @@
+---
+description: "Use when editing or verifying systemd user units and timers under insights/autostart/systemd/."
+applyTo: "insights/autostart/systemd/**/*"
+---
+
+# Systemd User Units and Timers Verification
+
+This directory contains user-level systemd units and timers used by the client for automated insights/collection workflows.
+
+## Verification Command
+
+Any change to files in this directory must immediately trigger verification using `systemd-analyze`:
+
+```bash
+systemd-analyze --user verify ./insights/autostart/systemd/*
+```
+
+## Conventions
+
+- Systemd service configurations must define clear dependencies and start-up constraints.
+- Timers must be verified against their triggering targets.

--- a/.github/skills/cgo-bindings/SKILL.md
+++ b/.github/skills/cgo-bindings/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: cgo-bindings
+description: "Handles C-bindings, building/testing of C/CGo assets, code generation, and C header verification. Use when working on C/CGo files under insights/C/."
+---
+
+# C/CGo and C-Bindings Operations
+
+## When to Use
+
+- Working on C header/source files or CGo wrappers in `insights/C/`.
+- Generating C assets or updating dynamic library mappings.
+- Validating native builds.
+
+## Setup and Native Host Requirements
+
+If building or testing Go modules with dynamic C dependencies _locally on your host_ (rather than inside a clean build environment or runner):
+
+- Ensure your path is set up for C compiling dependencies.
+- **Ubuntu/Debian host requirement** (not applicable/required on macOS/Windows except in cross-compilation environments):
+  ```bash
+  sudo apt update && sudo apt install -y libwayland-dev
+  ```
+
+## Procedures
+
+### 1) Code Generation (C Bindings)
+
+When any C-headers, CGo files, or bindings are modified:
+
+- Run CGo code generation from the repository root:
+  ```bash
+  go generate ./insights/C/...
+  ```
+- Make sure C/C++ style conforms to repo guidelines before committing.
+
+### 2) Lint and Format Checks
+
+- Enforce formatting of C/C++ headers and sources using `clang-format`:
+  - Run the CI gating script or manually format files in `insights/C/` using your preferred clang-format wrapper.
+
+### 3) C/CGo Integration & Thread-Safety Verification
+
+C/CGo boundaries are highly susceptible to memory access violations, thread linkage errors, and race conditions.
+
+- To verify modifications, always execute the C test suites with Go's **Concurrency Race Detector** enabled (refer to the `go-development` skill for general test execution):
+  ```bash
+  (cd insights && go test -count=1 -race ./C/...)
+  ```
+  _(Note: A pre-existing `nakedret` warning in `insights/C/libinsights.go` is known; call it out in PR comments if unrelated to your changes)._

--- a/.github/skills/debian-packaging/SKILL.md
+++ b/.github/skills/debian-packaging/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: debian-packaging
+description: "Handles Debian package building, dependency management, sbuild, and autopkgtest runs. Use when working under insights/debian/ or compiling .deb archives."
+---
+
+# Debian Packaging and Autopkgtests
+
+This skill covers the tools and procedures required to build and verify Debian packages in clean, isolated environments.
+
+## When to Use
+
+- Editing files under `insights/debian/` (such as `changelog`, `control`, `rules`).
+- Building the `.deb` client binary or source packages.
+- Running Debian package builds and autopkgtests.
+
+## Procedures
+
+### 1) Isolated Builds (SBuild) — SAFEST & RECOMMENDED
+
+To keep the developer's host environment clean and avoid dependency conflicts, package compilation should be run in isolated chroots.
+
+- Use the pre-configured VS Code tasks:
+  - **SBuild** task (`sbuild --source insights`): Builds the full debian binary package inside a secure sbuild chroot, automatically fetching the required build-deps.
+  - **SBuild Source Only** task.
+- To use sbuild from the CLI (if sbuild is configured on your system):
+  ```bash
+  sbuild --source insights
+  ```
+
+### 2) Running Autopkgtests & Smoke Tests
+
+Autopkgtests are defined in `insights/debian/tests/control` and verify package functionality:
+
+- **Go Tests (`run-tests.sh`)**: Runs standard module tests inside the package build environment.
+- **Smoke Tests (`run-smoke-tests.sh`)**: Relies on user systemd and dbus-user-session behavior.
+- _Troubleshooting Smoke Tests_: If smoke tests fail in container or VM test runners, ensure that systemd-logind is active and a user-systemd/dbus bus can be reached (via `loginctl` lingering user sessions and active user bus sessions).

--- a/.github/skills/go-development/SKILL.md
+++ b/.github/skills/go-development/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: go-development
+description: "Handles Go dependency bootstrapping, testing (including -race detector), and linting. Use when checking, validating, or running test suites for Go modules."
+---
+
+# Go Development and Testing
+
+This skill provides on-demand workflows for bootstrapping dependencies, running standard or race-detecting tests, and running linters.
+
+## When to Use
+
+- Initializing/bootstrapping the workspace dependencies.
+- Running package tests or looking for concurrent issues using the race detector.
+- Running golangci-lint to verify code style and standards compliance locally.
+
+## Procedures
+
+### 1) Bootstrapping Dependencies
+
+Download Go module dependencies per workspace module. It is recommended to do this per module rather than a single workspace download to avoid network/tool timeouts:
+
+```bash
+(cd common && go mod download)
+(cd insights && go mod download)
+(cd server && go mod download)
+(cd tools && go mod download)
+```
+
+### 2) Running Tests (Standard & Race Detector)
+
+Always run tests before pushing changes. This verifies both logical correctness and concurrent thread safety.
+
+#### Standard Unit & Integration Tests (Faster)
+
+Run regular non-race test checks:
+
+```bash
+(cd common && go test -count=1 ./...)
+(cd insights && go test -count=1 ./...)
+(cd server && go test -count=1 ./...)
+```
+
+#### Race Detection Tests (Highly Recommended)
+
+Telemetry collection runs asynchronously. Identifying concurrency bugs and data races is a hard requirement. It is highly recommended to run tests with Go's race detector active:
+
+```bash
+(cd common && go test -count=1 -race ./...)
+(cd insights && go test -count=1 -race ./...)
+(cd server && go test -count=1 -race ./...)
+```
+
+_(Note: Docker or a Docker-compatible engine is required for running server-side integration tests as they rely on `testcontainers-go`)_.
+
+### 3) Code Audits and Linting
+
+Run `golangci-lint` utilizing the repository's shared configuration to match CI guidelines:
+
+```bash
+(cd common && go tool golangci-lint run --config ../.golangci.yaml)
+(cd insights && go tool golangci-lint run --config ../.golangci.yaml)
+(cd server && go tool golangci-lint run --config ../.golangci.yaml)
+```
+
+### 4) Building Modules (Optional / Debugging only)
+
+_Warning: Running compilation builds is unnecessary for daily development, lints, or test runs. Avoid compiling binary outputs unless specifically needed for deployment, packaging, or debugging. Building binaries risks leaving unwanted, untracked binary files (_.deb, binary executables) in the workspace.\*
+
+If you must compile a binary output for diagnostic testing:
+
+- **Client CommandLine Interface**:
+  ```bash
+  go build -o ubuntu-insights ./insights/cmd/insights
+  ```
+- **Server Services**:
+  ```bash
+  go build ./server/cmd/web-service ./server/cmd/ingest-service
+  ```


### PR DESCRIPTION
Here, we add a number of experimental Copilot instruction files. These describe the project structure and the stack, as well as conventions that the repository uses that may not be obvious or widespread.

---
[UDENG-9037](https://warthogs.atlassian.net/browse/UDENG-9037)

[UDENG-9037]: https://warthogs.atlassian.net/browse/UDENG-9037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ