### PR TITLE
fix(qa): Specify go version file for code sanity checks

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -73,6 +73,7 @@ jobs:
         uses: canonical/desktop-engineering/gh-actions/go/code-sanity@v2
         with:
           working-directory: ${{ matrix.module }}
+          go-version-file: ${{ github.workspace }}/go.work
           tools-directory: ${{ github.workspace }}/tools
           golangci-lint-configfile: ${{ github.workspace }}/.golangci.yaml
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.25.0
 
-toolchain go1.25.10
+toolchain go1.25.11
 
 use (
 	./common

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -325,6 +325,7 @@ github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvM
 github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTUGI4=
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
+github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/quasilyte/go-ruleguard v0.4.5 h1:AGY0tiOT5hJX9BTdx/xBdoCubQUAE2grkqY2lSwvZcA=
 github.com/quasilyte/go-ruleguard v0.4.5/go.mod h1:Vl05zJ538vcEEwu16V/Hdu7IYZWyKSwIy4c88Ro1kRE=
 github.com/quasilyte/go-ruleguard/dsl v0.3.23 h1:lxjt5B6ZCiBeeNO8/oQsegE6fLeCzuMRoVWSkXC4uvY=


### PR DESCRIPTION
To fix the go-sanity job, we need to now specify for it to consider the root `go.work` as the source of truth for the go version to use.

To resolve some CVE issues, we also bump the toolchain version to 1.25.11.