### PR TITLE
feat(insights): query Ubuntu Pro attach state over D-Bus with CLI fallback

### DIFF
--- a/insights/debian/copyright
+++ b/insights/debian/copyright
@@ -29,6 +29,10 @@ Copyright: fsnotify Authors.
  2012, The Go Authors.
 License: BSD-3-clause
 
+Files: vendor/github.com/godbus/dbus/v5/*
+Copyright: 2013, Georg Reinke <guelfey@gmail.com>, Google
+License: BSD-2-clause
+
 Files: vendor/github.com/go-viper/mapstructure/v2/*
 Copyright: 2013, Mitchell Hashimoto
 License: Expat

--- a/insights/go.mod
+++ b/insights/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/insights/go.sum
+++ b/insights/go.sum
@@ -13,6 +13,8 @@ github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx5
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/insights/internal/collector/sysinfo/platform/export_linux_test.go
+++ b/insights/internal/collector/sysinfo/platform/export_linux_test.go
@@ -1,5 +1,11 @@
 package platform
 
+import (
+	"errors"
+
+	"github.com/godbus/dbus/v5"
+)
+
 // WithRoot sets the root directory for the platform collector.
 func WithRoot(root string) Options {
 	return func(o *options) {
@@ -32,6 +38,68 @@ func WithWSLVersionCmd(cmd []string) Options {
 func WithProStatusCmd(cmd []string) Options {
 	return func(o *options) {
 		o.platform.proStatusCmd = cmd
+	}
+}
+
+// fakeProDBusObject is a fake proDBusObject returning a preconfigured value or error.
+type fakeProDBusObject struct {
+	value any
+	err   error
+}
+
+func (o fakeProDBusObject) GetProperty(string) (dbus.Variant, error) {
+	if o.err != nil {
+		return dbus.Variant{}, o.err
+	}
+	return dbus.MakeVariant(o.value), nil
+}
+
+// fakeProDBusConn is a fake proDBusConn returning a preconfigured object.
+type fakeProDBusConn struct {
+	obj proDBusObject
+}
+
+func (c fakeProDBusConn) Object(string, dbus.ObjectPath) proDBusObject {
+	return c.obj
+}
+
+func (c fakeProDBusConn) Close() error {
+	return nil
+}
+
+// ProDBusSpec identifies which fake D-Bus behaviour WithProDBusConnector injects.
+type ProDBusSpec int
+
+const (
+	// ProDBusConnectError makes the connector itself fail (default/zero value).
+	ProDBusConnectError ProDBusSpec = iota
+	// ProDBusAttached makes the connector report an attached state.
+	ProDBusAttached
+	// ProDBusDetached makes the connector report a detached state.
+	ProDBusDetached
+	// ProDBusPropertyError makes the connection succeed but reading the property fail.
+	ProDBusPropertyError
+	// ProDBusGarbage makes the connection succeed but return an unexpected property type.
+	ProDBusGarbage
+)
+
+// WithProDBusConnector sets the pro D-Bus connector for the platform collector.
+func WithProDBusConnector(spec ProDBusSpec) Options {
+	return func(o *options) {
+		o.platform.proDBusConnector = func() (proDBusConn, error) {
+			switch spec {
+			case ProDBusAttached:
+				return fakeProDBusConn{obj: fakeProDBusObject{value: true}}, nil
+			case ProDBusDetached:
+				return fakeProDBusConn{obj: fakeProDBusObject{value: false}}, nil
+			case ProDBusPropertyError:
+				return fakeProDBusConn{obj: fakeProDBusObject{err: errors.New("fake property error")}}, nil
+			case ProDBusGarbage:
+				return fakeProDBusConn{obj: fakeProDBusObject{value: "not a bool"}}, nil
+			default: // ProDBusConnectError
+				return nil, errors.New("fake connect error")
+			}
+		}
 	}
 }
 

--- a/insights/internal/collector/sysinfo/platform/platform_linux.go
+++ b/insights/internal/collector/sysinfo/platform/platform_linux.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/godbus/dbus/v5"
 	"github.com/ubuntu/decorate"
 	"github.com/ubuntu/ubuntu-insights/common/fileutils"
 	"github.com/ubuntu/ubuntu-insights/insights/internal/cmdutils"
@@ -18,6 +19,50 @@ import (
 	"golang.org/x/text/transform"
 	"gopkg.in/ini.v1"
 )
+
+// Ubuntu Pro D-Bus interface details, as exposed by ubuntu-advantage-desktop-daemon
+// on the system bus. This is used in preference to the `pro` CLI for improved
+// compatibility with confined snaps (via the ubuntu-pro-control interface).
+const (
+	proDBusDest  = "com.canonical.UbuntuAdvantage"
+	proDBusPath  = "/com/canonical/UbuntuAdvantage/Manager"
+	proDBusIface = "com.canonical.UbuntuAdvantage.Manager"
+	proDBusProp  = proDBusIface + ".Attached"
+)
+
+// proDBusObject is the subset of dbus.BusObject used to read the attach state.
+type proDBusObject interface {
+	GetProperty(p string) (dbus.Variant, error)
+}
+
+// proDBusConn is the subset of *dbus.Conn used to read the attach state.
+// It is an interface to allow injecting a fake connection in tests.
+type proDBusConn interface {
+	Object(dest string, path dbus.ObjectPath) proDBusObject
+	Close() error
+}
+
+// systemBusConn wraps a *dbus.Conn to satisfy proDBusConn.
+type systemBusConn struct {
+	conn *dbus.Conn
+}
+
+func (c systemBusConn) Object(dest string, path dbus.ObjectPath) proDBusObject {
+	return c.conn.Object(dest, path)
+}
+
+func (c systemBusConn) Close() error {
+	return c.conn.Close()
+}
+
+// connectSystemBus connects to the system bus and returns a proDBusConn.
+func connectSystemBus() (proDBusConn, error) {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return nil, err
+	}
+	return systemBusConn{conn: conn}, nil
+}
 
 // Info contains platform information for Linux.
 type Info struct {
@@ -49,6 +94,8 @@ type platformOptions struct {
 	wslVersionCmd     []string
 	proStatusCmd      []string
 
+	proDBusConnector func() (proDBusConn, error)
+
 	getenv func(key string) string
 }
 
@@ -60,6 +107,8 @@ func defaultPlatformOptions() platformOptions {
 		systemdAnalyzeCmd: []string{"systemd-analyze", "time", "--system"},
 		wslVersionCmd:     []string{"wsl.exe", "-v"},
 		proStatusCmd:      []string{"pro", "api", "u.pro.status.is_attached.v1"},
+
+		proDBusConnector: connectSystemBus,
 
 		getenv: os.Getenv,
 	}
@@ -273,11 +322,52 @@ func (p Collector) getDesktop() Desktop {
 }
 
 // isProAttached returns the attach state of Ubuntu Pro.
+//
+// It first attempts to query the state over D-Bus, which works inside confined
+// snaps via the ubuntu-pro-control interface. If that fails (for example, the
+// daemon is not installed or the system bus is unavailable), it falls back to
+// the `pro` CLI.
 func (p Collector) isProAttached() bool {
-	stdout, stderr, err := cmdutils.RunWithTimeout(context.Background(), 15*time.Second, p.platform.proStatusCmd[0], p.platform.proStatusCmd[1:]...)
+	attached, err := p.isProAttachedDBus()
+	if err == nil {
+		return attached
+	}
+	p.log.Debug("failed to get pro status over D-Bus, falling back to CLI", "error", err)
+
+	attached, err = p.isProAttachedCLI()
 	if err != nil {
 		p.log.Warn("failed to get pro status", "error", err)
 		return false
+	}
+	return attached
+}
+
+// isProAttachedDBus returns the attach state of Ubuntu Pro by reading the
+// Attached property from the ubuntu-advantage-desktop-daemon over the system bus.
+func (p Collector) isProAttachedDBus() (bool, error) {
+	conn, err := p.platform.proDBusConnector()
+	if err != nil {
+		return false, fmt.Errorf("failed to connect to system bus: %v", err)
+	}
+	defer conn.Close()
+
+	v, err := conn.Object(proDBusDest, proDBusPath).GetProperty(proDBusProp)
+	if err != nil {
+		return false, fmt.Errorf("failed to get %q property: %v", proDBusProp, err)
+	}
+
+	attached, ok := v.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("unexpected type %T for %q property", v.Value(), proDBusProp)
+	}
+	return attached, nil
+}
+
+// isProAttachedCLI returns the attach state of Ubuntu Pro using the `pro` CLI.
+func (p Collector) isProAttachedCLI() (bool, error) {
+	stdout, stderr, err := cmdutils.RunWithTimeout(context.Background(), 15*time.Second, p.platform.proStatusCmd[0], p.platform.proStatusCmd[1:]...)
+	if err != nil {
+		return false, fmt.Errorf("failed to run pro api: %v", err)
 	}
 	if stderr.Len() > 0 {
 		p.log.Info("pro api output to stderr", "stderr", stderr)
@@ -291,10 +381,8 @@ func (p Collector) isProAttached() bool {
 			}
 		}
 	}
-	err = json.Unmarshal(stdout.Bytes(), &proStatus)
-	if err != nil {
-		p.log.Warn("failed to parse pro api return", "error", err)
-		return false
+	if err := json.Unmarshal(stdout.Bytes(), &proStatus); err != nil {
+		return false, fmt.Errorf("failed to parse pro api return: %v", err)
 	}
-	return proStatus.Data.Attributes.IsAttached
+	return proStatus.Data.Attributes.IsAttached, nil
 }

--- a/insights/internal/collector/sysinfo/platform/platform_linux_test.go
+++ b/insights/internal/collector/sysinfo/platform/platform_linux_test.go
@@ -29,6 +29,7 @@ func TestCollectLinux(t *testing.T) {
 		systemdAnalyzeCmd string
 		wslVersionCmd     string
 		proStatusCmd      string
+		proDBus           platform.ProDBusSpec
 		env               map[string]string
 
 		missingFiles []string
@@ -129,6 +130,47 @@ func TestCollectLinux(t *testing.T) {
 				"XDG_CURRENT_DESKTOP": "❤️",
 				"XDG_SESSION_DESKTOP": "(●'◡'●)",
 				"XDG_SESSION_TYPE":    "(╯°□°）╯︵ ┻━┻"},
+		},
+
+		// Pro D-Bus path (preferred over CLI).
+		"Pro attached over D-Bus does not use CLI": {
+			detectVirtCmd:     "none",
+			systemdAnalyzeCmd: "regular",
+			wslVersionCmd:     "error",
+			proStatusCmd:      "-", // CLI must not be needed.
+			proDBus:           platform.ProDBusAttached,
+		},
+		"Pro detached over D-Bus does not use CLI": {
+			detectVirtCmd:     "none",
+			systemdAnalyzeCmd: "regular",
+			wslVersionCmd:     "error",
+			proStatusCmd:      "-", // CLI must not be needed.
+			proDBus:           platform.ProDBusDetached,
+		},
+		"Pro D-Bus property error falls back to CLI attached": {
+			detectVirtCmd:     "none",
+			systemdAnalyzeCmd: "regular",
+			wslVersionCmd:     "error",
+			proStatusCmd:      "attached",
+			proDBus:           platform.ProDBusPropertyError,
+		},
+		"Pro D-Bus garbage type falls back to CLI detached": {
+			detectVirtCmd:     "none",
+			systemdAnalyzeCmd: "regular",
+			wslVersionCmd:     "error",
+			proStatusCmd:      "detached",
+			proDBus:           platform.ProDBusGarbage,
+		},
+		"Pro D-Bus and CLI both fail warns": {
+			detectVirtCmd:     "none",
+			systemdAnalyzeCmd: "regular",
+			wslVersionCmd:     "error",
+			proStatusCmd:      "error",
+			proDBus:           platform.ProDBusConnectError,
+
+			logs: map[slog.Level]uint{
+				slog.LevelWarn: 1,
+			},
 		},
 
 		// Other virt types
@@ -427,6 +469,10 @@ func TestCollectLinux(t *testing.T) {
 				cmdArgs := testutils.SetupFakeCmdArgs("TestFakeProStatus", tc.proStatusCmd)
 				options = append(options, platform.WithProStatusCmd(cmdArgs))
 			}
+
+			// Default (zero value) is ProDBusConnectError, so tests that do not set
+			// proDBus fall back to the `pro` CLI path being exercised above.
+			options = append(options, platform.WithProDBusConnector(tc.proDBus))
 
 			p := platform.New(slog.New(&l), options...)
 

--- a/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_attached_over_d-bus_does_not_use_cli
+++ b/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_attached_over_d-bus_does_not_use_cli
@@ -1,0 +1,11 @@
+wsl:
+    subsystemversion: 0
+    systemd: ""
+    interop: ""
+    version: ""
+    kernelversion: ""
+desktop:
+    desktopenvironment: ""
+    sessionname: ""
+    sessiontype: ""
+proattached: true

--- a/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_d-bus_and_cli_both_fail_warns
+++ b/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_d-bus_and_cli_both_fail_warns
@@ -1,0 +1,11 @@
+wsl:
+    subsystemversion: 0
+    systemd: ""
+    interop: ""
+    version: ""
+    kernelversion: ""
+desktop:
+    desktopenvironment: ""
+    sessionname: ""
+    sessiontype: ""
+proattached: false

--- a/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_d-bus_garbage_type_falls_back_to_cli_detached
+++ b/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_d-bus_garbage_type_falls_back_to_cli_detached
@@ -1,0 +1,11 @@
+wsl:
+    subsystemversion: 0
+    systemd: ""
+    interop: ""
+    version: ""
+    kernelversion: ""
+desktop:
+    desktopenvironment: ""
+    sessionname: ""
+    sessiontype: ""
+proattached: false

--- a/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_d-bus_property_error_falls_back_to_cli_attached
+++ b/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_d-bus_property_error_falls_back_to_cli_attached
@@ -1,0 +1,11 @@
+wsl:
+    subsystemversion: 0
+    systemd: ""
+    interop: ""
+    version: ""
+    kernelversion: ""
+desktop:
+    desktopenvironment: ""
+    sessionname: ""
+    sessiontype: ""
+proattached: true

--- a/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_detached_over_d-bus_does_not_use_cli
+++ b/insights/internal/collector/sysinfo/platform/testdata/TestCollectLinux/golden/pro_detached_over_d-bus_does_not_use_cli
@@ -1,0 +1,11 @@
+wsl:
+    subsystemversion: 0
+    systemd: ""
+    interop: ""
+    version: ""
+    kernelversion: ""
+desktop:
+    desktopenvironment: ""
+    sessionname: ""
+    sessiontype: ""
+proattached: false

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,7 @@ apps:
       - wayland
       - x11
       - network # Needed for uploading
-      # - ubuntu-pro-control # Doesn't work atm, needs we need to use the dbus interface directly.
+      - ubuntu-pro-control # Used to read the Ubuntu Pro attach state over D-Bus.
       - dot-config-ubuntu-insights # Default config location
       - dot-cache-ubuntu-insights # Default cache location
       - block-devices # Required to see encrypted partitions. `dm-crypt` also works.


### PR DESCRIPTION
This pull request enhances the detection of Ubuntu Pro attach state on Linux by adding support for querying the status over D-Bus, which is more compatible with confined snaps. The code now prefers the D-Bus interface (via the `ubuntu-pro-control` snap plug) and falls back to the `pro` CLI if D-Bus is unavailable or fails. The update includes new test infrastructure for simulating D-Bus scenarios, expanded test coverage, and updates to the snap configuration.

**Ubuntu Pro attach state detection improvements:**

* Added D-Bus-based detection for Ubuntu Pro attach state in `platform_linux.go`, using the `com.canonical.UbuntuAdvantage` interface, and falling back to the CLI if D-Bus is unavailable or returns an error. [[1]](diffhunk://#diff-09ad6495d3e57a4f26bf6c1a2861d394eabf2b44082a70c47940439760ec05d1R23-R66) [[2]](diffhunk://#diff-09ad6495d3e57a4f26bf6c1a2861d394eabf2b44082a70c47940439760ec05d1R325-R371)
* Refactored the attach state check to separate D-Bus (`isProAttachedDBus`) and CLI (`isProAttachedCLI`) logic, improving error handling and logging. [[1]](diffhunk://#diff-09ad6495d3e57a4f26bf6c1a2861d394eabf2b44082a70c47940439760ec05d1R325-R371) [[2]](diffhunk://#diff-09ad6495d3e57a4f26bf6c1a2861d394eabf2b44082a70c47940439760ec05d1L294-R387)
* Updated the snapcraft configuration to enable the `ubuntu-pro-control` interface, allowing D-Bus access in snaps.

**Testing infrastructure and coverage:**

* Added test doubles and a configurable D-Bus connector (`WithProDBusConnector`) for simulating various D-Bus and CLI behaviors in tests, ensuring robust coverage of fallback and error-handling logic. [[1]](diffhunk://#diff-14a729beaa046c3c77b291f7248f53aaa8500750e62b1bbecc1ba65b808a2806R44-R96) [[2]](diffhunk://#diff-14a729beaa046c3c77b291f7248f53aaa8500750e62b1bbecc1ba65b808a2806R3-R8)
* Expanded test cases in `platform_linux_test.go` to cover all D-Bus and CLI fallback scenarios, and added corresponding golden files for expected outputs. [[1]](diffhunk://#diff-de81a63def9a032f094d3eb286280d40a7d9ee698c76a51c6b3b1ac3add78781R135-R175) [[2]](diffhunk://#diff-de81a63def9a032f094d3eb286280d40a7d9ee698c76a51c6b3b1ac3add78781R473-R480) [[3]](diffhunk://#diff-d989f457d454ec18a3bbb4b1f8339642abd9c41b3d5852e73fdc8a784cc47072R1-R11) [[4]](diffhunk://#diff-ee8e8a5a611efe2b30584f6d292f311c9c264e49e4c5a61af0918c425de49a42R1-R11)

**Dependency updates:**

* Added the `github.com/godbus/dbus/v5` dependency for D-Bus communication support. [[1]](diffhunk://#diff-d33ec6dc9d05b95c6c3f9500f318a0c6e5915bff5f0e421ca90a41163e377df1R7) [[2]](diffhunk://#diff-09ad6495d3e57a4f26bf6c1a2861d394eabf2b44082a70c47940439760ec05d1R14)

These changes make Ubuntu Pro attach state detection more robust and compatible with modern Linux environments, especially when running as a confined snap.

---
[UDENG-9920](https://warthogs.atlassian.net/browse/UDENG-9920)

[UDENG-9920]: https://warthogs.atlassian.net/browse/UDENG-9920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ