### PR TITLE
fix(mediawiki): rename accelerator kind to type

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Ubuntu Insights is divided into two components:
           "device": "0x17f0",
           "vendor": "0x1022",
           "driver": "amdxdna",
-          "kind": "0x120000"
+          "type": "0x120000"
         }
       ],
       "memory": {

--- a/insights/internal/collector/sysinfo/hardware/hardware.go
+++ b/insights/internal/collector/sysinfo/hardware/hardware.go
@@ -51,7 +51,7 @@ type accelerator struct {
 	Device string `json:"device,omitempty"`
 	Vendor string `json:"vendor,omitempty"`
 	Driver string `json:"driver,omitempty"`
-	Kind   string `json:"kind,omitempty"`
+	Type   string `json:"type,omitempty"`
 }
 
 // memory contains information for the system's memory.

--- a/insights/internal/collector/sysinfo/hardware/hardware_linux.go
+++ b/insights/internal/collector/sysinfo/hardware/hardware_linux.go
@@ -298,7 +298,7 @@ func (h Collector) collectAccelerator(accelName string) (info accelerator, err e
 	info.Vendor = fileutils.ReadFileLogError(filepath.Join(devDir, "vendor"), h.log)
 	info.Name = fileutils.ReadFileLog(filepath.Join(devDir, "label"), h.log, slog.LevelInfo) // label is not always present
 	info.Device = fileutils.ReadFileLogError(filepath.Join(devDir, "device"), h.log)
-	info.Kind = fileutils.ReadFileLog(filepath.Join(devDir, "class"), h.log, slog.LevelInfo) // class is not always present
+	info.Type = fileutils.ReadFileLog(filepath.Join(devDir, "class"), h.log, slog.LevelInfo) // class is not always present
 
 	if strings.ContainsRune(info.Vendor, '\n') {
 		h.log.Warn("acceleration device vendor contains invalid value", "device", accelName)
@@ -312,9 +312,9 @@ func (h Collector) collectAccelerator(accelName string) (info accelerator, err e
 		h.log.Warn("acceleration device ID contains invalid value", "device", accelName)
 		info.Device = ""
 	}
-	if strings.ContainsRune(info.Kind, '\n') {
+	if strings.ContainsRune(info.Type, '\n') {
 		h.log.Warn("acceleration device class contains invalid value", "device", accelName)
-		info.Kind = ""
+		info.Type = ""
 	}
 
 	driverLink, err := os.Readlink(filepath.Join(devDir, "driver"))

--- a/insights/internal/collector/sysinfo/hardware/hardware_windows.go
+++ b/insights/internal/collector/sysinfo/hardware/hardware_windows.go
@@ -176,7 +176,7 @@ func (s Collector) collectAccelerators(_ platform.Info) ([]accelerator, error) {
 			Name:   a["Name"],
 			Vendor: a["Manufacturer"],
 			Device: a["HardwareID"],
-			Kind:   a["PNPClass"],
+			Type:   a["PNPClass"],
 		})
 	}
 	return result, nil

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/accelerator_information_with_invalid_values_warns
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/accelerator_information_with_invalid_values_warns
@@ -1,69 +1,69 @@
 product:
-  family: Framework DIY
-  name: DIY Framework Laptop 16
-  vendor: Framework
+    family: Framework DIY
+    name: DIY Framework Laptop 16
+    vendor: Framework
 cpu:
-  name: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
-  vendor: GenuineIntel
-  arch: x86_64
-  cpus: 12
-  sockets: 1
-  cores: 6
-  threads: 2
+    name: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+    vendor: GenuineIntel
+    arch: x86_64
+    cpus: 12
+    sockets: 1
+    cores: 6
+    threads: 2
 gpus:
-  - name: Onboard - Video
-    device: 0xdevice0
-    vendor: "0x8086"
-    driver: i915
-  - name: NVIDIA GeForce GTX 1050 Ti
-    device: 0xdevice1
-    vendor: "0x10de"
-    driver: nvidia
+    - name: Onboard - Video
+      device: 0xdevice0
+      vendor: "0x8086"
+      driver: i915
+    - name: NVIDIA GeForce GTX 1050 Ti
+      device: 0xdevice1
+      vendor: "0x10de"
+      driver: nvidia
 accelerators:
-  - name: ""
-    device: ""
-    vendor: ""
-    driver: intel_vpu
-    kind: ""
+    - name: ""
+      device: ""
+      vendor: ""
+      driver: intel_vpu
+      type: ""
 mem:
-  total: 31941
+    total: 31941
 blks:
-  - size: 953856
-    type: disk
-    children:
-      - size: 1024
-        type: part
-        children: []
-      - size: 2048
-        type: part
-        children: []
-      - size: 950784
-        type: part
-        children:
-          - size: 950681
-            type: crypt
-            children:
-              - size: 950681
-                type: lvm
-                children: []
-      - size: 358400
-        type: part
-        children:
-          - size: 179200
-            type: part
-            children: []
-          - size: 102400
-            type: part
-            children: []
-          - size: 76800
-            type: part
-            children: []
+    - size: 953856
+      type: disk
+      children:
+        - size: 1024
+          type: part
+          children: []
+        - size: 2048
+          type: part
+          children: []
+        - size: 950784
+          type: part
+          children:
+            - size: 950681
+              type: crypt
+              children:
+                - size: 950681
+                  type: lvm
+                  children: []
+        - size: 358400
+          type: part
+          children:
+            - size: 179200
+              type: part
+              children: []
+            - size: 102400
+              type: part
+              children: []
+            - size: 76800
+              type: part
+              children: []
 screens:
-  - physicalresolution: ""
-    size: 598mm x 336mm
-    resolution: 1920x1080
-    refreshrate: "60.00"
-  - physicalresolution: ""
-    size: 344mm x 193mm
-    resolution: 1920x1080
-    refreshrate: "60.03"
+    - physicalresolution: ""
+      size: 598mm x 336mm
+      resolution: 1920x1080
+      refreshrate: "60.00"
+    - physicalresolution: ""
+      size: 344mm x 193mm
+      resolution: 1920x1080
+      refreshrate: "60.03"

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/bad_block_nesting_depth
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/bad_block_nesting_depth
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/cpu_information_with_negative_values_is_handled
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/cpu_information_with_negative_values_is_handled
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_block_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_block_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks: []

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_collecting_accelerator_information_warns
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_collecting_accelerator_information_warns
@@ -1,64 +1,64 @@
 product:
-  family: Framework DIY
-  name: DIY Framework Laptop 16
-  vendor: Framework
+    family: Framework DIY
+    name: DIY Framework Laptop 16
+    vendor: Framework
 cpu:
-  name: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
-  vendor: GenuineIntel
-  arch: x86_64
-  cpus: 12
-  sockets: 1
-  cores: 6
-  threads: 2
+    name: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+    vendor: GenuineIntel
+    arch: x86_64
+    cpus: 12
+    sockets: 1
+    cores: 6
+    threads: 2
 gpus:
-  - name: Onboard - Video
-    device: 0xdevice0
-    vendor: "0x8086"
-    driver: i915
-  - name: NVIDIA GeForce GTX 1050 Ti
-    device: 0xdevice1
-    vendor: "0x10de"
-    driver: nvidia
+    - name: Onboard - Video
+      device: 0xdevice0
+      vendor: "0x8086"
+      driver: i915
+    - name: NVIDIA GeForce GTX 1050 Ti
+      device: 0xdevice1
+      vendor: "0x10de"
+      driver: nvidia
 accelerators: []
 mem:
-  total: 31941
+    total: 31941
 blks:
-  - size: 953856
-    type: disk
-    children:
-      - size: 1024
-        type: part
-        children: []
-      - size: 2048
-        type: part
-        children: []
-      - size: 950784
-        type: part
-        children:
-          - size: 950681
-            type: crypt
-            children:
-              - size: 950681
-                type: lvm
-                children: []
-      - size: 358400
-        type: part
-        children:
-          - size: 179200
-            type: part
-            children: []
-          - size: 102400
-            type: part
-            children: []
-          - size: 76800
-            type: part
-            children: []
+    - size: 953856
+      type: disk
+      children:
+        - size: 1024
+          type: part
+          children: []
+        - size: 2048
+          type: part
+          children: []
+        - size: 950784
+          type: part
+          children:
+            - size: 950681
+              type: crypt
+              children:
+                - size: 950681
+                  type: lvm
+                  children: []
+        - size: 358400
+          type: part
+          children:
+            - size: 179200
+              type: part
+              children: []
+            - size: 102400
+              type: part
+              children: []
+            - size: 76800
+              type: part
+              children: []
 screens:
-  - physicalresolution: ""
-    size: 598mm x 336mm
-    resolution: 1920x1080
-    refreshrate: "60.00"
-  - physicalresolution: ""
-    size: 344mm x 193mm
-    resolution: 1920x1080
-    refreshrate: "60.03"
+    - physicalresolution: ""
+      size: 598mm x 336mm
+      resolution: 1920x1080
+      refreshrate: "60.00"
+    - physicalresolution: ""
+      size: 344mm x 193mm
+      resolution: 1920x1080
+      refreshrate: "60.03"

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_cpu_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_cpu_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_no_exit_screen_warns
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_no_exit_screen_warns
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_screen_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/error_screen_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_block_information_is_empty
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_block_information_is_empty
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks: []

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_cpu_information_is_empty
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_cpu_information_is_empty
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_screen_information_is_empty
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/garbage_screen_information_is_empty
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_accelerator_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_accelerator_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: ""
       driver: ""
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_block_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_block_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks: []

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_cpu_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_cpu_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_gpu_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_gpu_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_gpus
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_gpus
@@ -16,7 +16,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_memory_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_memory_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 0
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_product_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_product_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_screen_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_screen_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_screen_refresh_information_is_empty
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/missing_screen_refresh_information_is_empty
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/regular_hardware_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/regular_hardware_information
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/some_cpu_information_is_derived_when_missing
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/some_cpu_information_is_derived_when_missing
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wayland_memoryerror_warns_and_falls_back
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wayland_memoryerror_warns_and_falls_back
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wayland_multipledisplays_is_sane
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wayland_multipledisplays_is_sane
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wayland_nodisplay_falls_back
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wayland_nodisplay_falls_back
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wayland_singledisplay_is_sane
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wayland_singledisplay_is_sane
@@ -24,7 +24,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wsl_hardware_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wsl_hardware_information
@@ -16,7 +16,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wsl_hardware_information_ignores_xrandr
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectLinux/golden/wsl_hardware_information_ignores_xrandr
@@ -16,7 +16,7 @@ accelerators:
       device: "0x643e"
       vendor: "0x8086"
       driver: intel_vpu
-      kind: "0x120000"
+      type: "0x120000"
 mem:
     total: 31941
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/multiple_acceleration_devices_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/multiple_acceleration_devices_information
@@ -24,12 +24,12 @@ accelerators:
       device: '{PCI\VEN_8086&DEV_7D1D&SUBSYS_00000000&REV_00, PCI\VEN_8086&DEV_7D1D, PCI\VEN_8086&CC_120000}'
       vendor: Intel Corporation
       driver: ""
-      kind: ComputeAccelerator
+      type: ComputeAccelerator
     - name: Qualcomm(R) Hexagon(TM) NPU
       device: '{ACPI\QCOM0C89, *QCOM0C89}'
       vendor: Qualcomm Technologies, Inc.
       driver: ""
-      kind: NeuralProcessor
+      type: NeuralProcessor
 mem:
     total: 65237
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/regular_acceleration_device_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/regular_acceleration_device_information
@@ -24,7 +24,7 @@ accelerators:
       device: '{PCI\VEN_8086&DEV_7D1D&SUBSYS_00000000&REV_00, PCI\VEN_8086&DEV_7D1D, PCI\VEN_8086&CC_120000}'
       vendor: Intel Corporation
       driver: ""
-      kind: ComputeAccelerator
+      type: ComputeAccelerator
 mem:
     total: 65237
 blks:

--- a/insights/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/regular_hardware_information
+++ b/insights/internal/collector/sysinfo/hardware/testdata/TestCollectWindows/golden/regular_hardware_information
@@ -24,7 +24,7 @@ accelerators:
       device: '{PCI\VEN_8086&DEV_7D1D&SUBSYS_00000000&REV_00, PCI\VEN_8086&DEV_7D1D, PCI\VEN_8086&CC_120000}'
       vendor: Intel Corporation
       driver: ""
-      kind: ComputeAccelerator
+      type: ComputeAccelerator
 mem:
     total: 65237
 blks:


### PR DESCRIPTION
To keep things consistent, the accelerator "kind" should be referred to as "type". This makes this section consistent with the storage blocks.